### PR TITLE
[FEAT] 복습 노트 푸쉬 알림 기능 구현 완료

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!-- 카메라와 저장소가 필수가 아님을 명시 -->
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
@@ -38,9 +39,18 @@
             <meta-data
                 android:name="com.google.android.gms.auth.api.fallback"
                 android:value="true" />
+
+            <meta-data
+                android:name="com.google.firebase.messaging.default_notification_channel_id"
+                android:value="high_importance_channel" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="FLUTTER_NOTIFICATION_CLICK" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <!-- 카카오 로그인 커스텀 URL 스킴 설정 -->
@@ -66,6 +76,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="high_importance_channel" />
 
         <meta-data
             android:name="com.naver.sdk.clientId"

--- a/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -21,6 +21,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin camera_android_camerax, io.flutter.plugins.camerax.CameraAndroidCameraxPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new dev.fluttercommunity.plus.device_info.DeviceInfoPlusPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin device_info_plus, dev.fluttercommunity.plus.device_info.DeviceInfoPlusPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new io.flutter.plugins.firebase.analytics.FlutterFirebaseAnalyticsPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin firebase_analytics, io.flutter.plugins.firebase.analytics.FlutterFirebaseAnalyticsPlugin", e);
@@ -29,6 +34,11 @@ public final class GeneratedPluginRegistrant {
       flutterEngine.getPlugins().add(new io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin firebase_core, io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin", e);
+    }
+    try {
+      flutterEngine.getPlugins().add(new io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin firebase_messaging, io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingPlugin", e);
     }
     try {
       flutterEngine.getPlugins().add(new com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin());

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -64,10 +64,18 @@
 	<string>오답노트 등록에 필요한 사진을 직접 첨부하기 위해서는 마이크 접근 권한 허용이 필요합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>오답노트 등록에 필요한 사진을 직접 첨부하기 위해서는 갤러리 접근 권한 허용이 필요합니다.</string>
+	<key>NSUserNotificationUsageDescription</key>
+    <string>복습 알림을 보내기 위해 권한 허용이 필요합니다.</string>
 	<key>NSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+		<string>remote-notification</string>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -78,6 +78,12 @@
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+    <false/>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+      <key>NSAllowsArbitraryLoads</key><true/>
+    </dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/lib/Model/PracticeNote/PracticeNoteDetailModel.dart
+++ b/lib/Model/PracticeNote/PracticeNoteDetailModel.dart
@@ -1,4 +1,5 @@
 import 'package:intl/intl.dart';
+import 'package:ono/Model/PracticeNote/PracticeNotificationModel.dart';
 
 class PracticeNoteDetailModel {
   final int practiceId;
@@ -7,6 +8,7 @@ class PracticeNoteDetailModel {
   final int practiceSize;
   final DateTime createdAt;
   final DateTime? lastSolvedAt;
+  final PracticeNotificationModel? practiceNotificationModel;
   List<int> problemIdList = [];
 
   PracticeNoteDetailModel({
@@ -16,12 +18,16 @@ class PracticeNoteDetailModel {
     required this.practiceSize,
     required this.createdAt,
     required this.lastSolvedAt,
+    this.practiceNotificationModel,
     required this.problemIdList,
   });
 
   factory PracticeNoteDetailModel.fromJson(Map<String, dynamic> json) {
     final problemIdDynamic = json['problemIdList'] as List<dynamic>? ?? [];
     final problemIdList = problemIdDynamic.map((e) => e as int).toList();
+    final practiceNotificationModel = json['practiceNotification'] != null
+        ? PracticeNotificationModel.fromJson(json['practiceNotification'])
+        : null;
 
     return PracticeNoteDetailModel(
       practiceId: json['practiceNoteId'],
@@ -33,6 +39,7 @@ class PracticeNoteDetailModel {
       lastSolvedAt: json['lastSolvedAt'] != null
           ? DateTime.parse(json['lastSolvedAt']).add(const Duration(hours: 9))
           : null,
+      practiceNotificationModel: practiceNotificationModel,
       problemIdList: problemIdList,
     );
   }

--- a/lib/Model/PracticeNote/PracticeNoteRegisterModel.dart
+++ b/lib/Model/PracticeNote/PracticeNoteRegisterModel.dart
@@ -1,16 +1,24 @@
+import 'package:ono/Model/PracticeNote/PracticeNotificationModel.dart';
+
 class PracticeNoteRegisterModel {
   final int? practiceId;
   String practiceTitle;
   final List<int> registerProblemIdList;
+  PracticeNotificationModel? practiceNotificationModel;
 
   PracticeNoteRegisterModel({
     this.practiceId,
     required this.practiceTitle,
     required this.registerProblemIdList,
+    this.practiceNotificationModel,
   });
 
   void setPracticeTitle(String newTitle) {
     practiceTitle = newTitle;
+  }
+
+  void setPracticeNotificationModel(practiceNotificationModel) {
+    this.practiceNotificationModel = practiceNotificationModel;
   }
 
   Map<String, dynamic> toJson() {
@@ -18,6 +26,8 @@ class PracticeNoteRegisterModel {
       'practiceId': practiceId,
       'practiceTitle': practiceTitle,
       'problemIdList': registerProblemIdList,
+      if (practiceNotificationModel != null)
+        'practiceNotification': practiceNotificationModel!.toJson(),
     };
   }
 }

--- a/lib/Model/PracticeNote/PracticeNoteUpdateModel.dart
+++ b/lib/Model/PracticeNote/PracticeNoteUpdateModel.dart
@@ -1,18 +1,26 @@
+import 'PracticeNotificationModel.dart';
+
 class PracticeNoteUpdateModel {
   final int practiceNoteId;
   String? practiceTitle;
   final List<int> addProblemIdList;
   final List<int> removeProblemIdList;
+  PracticeNotificationModel? practiceNotificationModel;
 
   PracticeNoteUpdateModel({
     required this.practiceNoteId,
     this.practiceTitle,
     required this.addProblemIdList,
     required this.removeProblemIdList,
+    this.practiceNotificationModel,
   });
 
   void setPracticeTitle(String newTitle) {
     practiceTitle = newTitle;
+  }
+
+  void setPracticeNotificationModel(practiceNotificationModel) {
+    this.practiceNotificationModel = practiceNotificationModel;
   }
 
   Map<String, dynamic> toJson() {
@@ -21,6 +29,8 @@ class PracticeNoteUpdateModel {
       'practiceTitle': practiceTitle,
       'addProblemIdList': addProblemIdList,
       'removeProblemIdList': removeProblemIdList,
+      if (practiceNotificationModel != null)
+        'practiceNotification': practiceNotificationModel!.toJson(),
     };
   }
 }

--- a/lib/Model/PracticeNote/PracticeNotificationModel.dart
+++ b/lib/Model/PracticeNote/PracticeNotificationModel.dart
@@ -20,7 +20,7 @@ class PracticeNotificationModel {
     };
   }
 
-  PracticeNotificationModel fromJson(Map<String, dynamic> json) {
+  factory PracticeNotificationModel.fromJson(Map<String, dynamic> json) {
     return PracticeNotificationModel(
       intervalDays: json['intervalDays'] ?? 7,
       hour: json['hour'] ?? 18,

--- a/lib/Model/PracticeNote/PracticeNotificationModel.dart
+++ b/lib/Model/PracticeNote/PracticeNotificationModel.dart
@@ -1,0 +1,31 @@
+class PracticeNotificationModel {
+  final int? intervalDays;
+  final int? hour;
+  final int? minute;
+  final int? notifyCount;
+
+  PracticeNotificationModel({
+    this.intervalDays,
+    this.hour,
+    this.minute,
+    this.notifyCount,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'intervalDays': intervalDays,
+      'hour': hour,
+      'minute': minute,
+      'notifyCount': notifyCount,
+    };
+  }
+
+  PracticeNotificationModel fromJson(Map<String, dynamic> json) {
+    return PracticeNotificationModel(
+      intervalDays: json['intervalDays'] ?? 7,
+      hour: json['hour'] ?? 18,
+      minute: json['minute'] ?? 0,
+      notifyCount: json['notifyCount'] ?? 3,
+    );
+  }
+}

--- a/lib/Model/PracticeNote/PracticeNotificationModel.dart
+++ b/lib/Model/PracticeNote/PracticeNotificationModel.dart
@@ -1,14 +1,18 @@
+import 'package:ono/Model/PracticeNote/RepeatType.dart';
+
 class PracticeNotificationModel {
   final int? intervalDays;
   final int? hour;
   final int? minute;
-  final int? notifyCount;
+  final RepeatType? repeatType;
+  final List<int>? weekDays;
 
   PracticeNotificationModel({
     this.intervalDays,
     this.hour,
     this.minute,
-    this.notifyCount,
+    this.repeatType,
+    this.weekDays,
   });
 
   Map<String, dynamic> toJson() {
@@ -16,7 +20,8 @@ class PracticeNotificationModel {
       'intervalDays': intervalDays,
       'hour': hour,
       'minute': minute,
-      'notifyCount': notifyCount,
+      'repeatType': repeatType?.name,
+      'weekDays': weekDays,
     };
   }
 
@@ -25,7 +30,14 @@ class PracticeNotificationModel {
       intervalDays: json['intervalDays'] ?? 7,
       hour: json['hour'] ?? 18,
       minute: json['minute'] ?? 0,
-      notifyCount: json['notifyCount'] ?? 3,
+      repeatType: json['repeatType'] is String
+          ? RepeatType.values.firstWhere(
+              (e) => e.name == json['repeatType'],
+              orElse: () => RepeatType.daily,
+            )
+          : RepeatType.daily,
+      weekDays:
+          (json['weekDays'] as List<dynamic>?)?.map((e) => e as int).toList(),
     );
   }
 }

--- a/lib/Model/PracticeNote/RepeatType.dart
+++ b/lib/Model/PracticeNote/RepeatType.dart
@@ -1,0 +1,1 @@
+enum RepeatType { daily, weekly }

--- a/lib/Model/Problem/ProblemImageDataRegisterModel.dart
+++ b/lib/Model/Problem/ProblemImageDataRegisterModel.dart
@@ -1,7 +1,7 @@
 import '../Common/ProblemImageDataType.dart';
 
 class ProblemImageDataRegisterModel {
-  final int problemId;
+  final int? problemId;
   final String imageUrl;
   final ProblemImageType problemImageType;
 

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -77,7 +77,8 @@ class ProblemPracticeProvider with ChangeNotifier {
       log('practiceNotification interval days: ${practice.practiceNotificationModel?.intervalDays}');
       log('practiceNotification hour: ${practice.practiceNotificationModel?.hour}');
       log('practiceNotification minute: ${practice.practiceNotificationModel?.minute}');
-      log('practiceNotification notifyCount: ${practice.practiceNotificationModel?.weekDays}');
+      log('practiceNotification repeatType: ${practice.practiceNotificationModel?.repeatType}');
+      log('practiceNotification weekDays: ${practice.practiceNotificationModel?.weekDays}');
       log('-----------------------------------------');
     }
     notifyListeners();

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -48,7 +48,7 @@ class ProblemPracticeProvider with ChangeNotifier {
         await practiceNoteService.getPracticeNoteById(practiceNoteId!);
 
     final index = _practices
-        .indexWhere((folder) => practiceNote.practiceId == practiceNoteId);
+        .indexWhere((practice) => practice.practiceId == practiceNoteId);
     if (index != -1) {
       _practices[index] = practiceNote;
       if (currentPracticeNote != null) {
@@ -101,7 +101,6 @@ class ProblemPracticeProvider with ChangeNotifier {
     int createdPracticeId = await practiceNoteService
         .registerPracticeNote(practiceNoteRegisterModel);
 
-    log(createdPracticeId.toString());
     await fetchPracticeNote(createdPracticeId);
   }
 

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -72,6 +72,10 @@ class ProblemPracticeProvider with ChangeNotifier {
       log('practice Name: ${practice.practiceTitle}');
       log('lastSolved at: ${practice.lastSolvedAt}');
       log('practiceCount: ${practice.practiceCount}');
+      log('practiceNotification interval days: ${practice.practiceNotificationModel?.intervalDays}');
+      log('practiceNotification hour: ${practice.practiceNotificationModel?.hour}');
+      log('practiceNotification minute: ${practice.practiceNotificationModel?.minute}');
+      log('practiceNotification notifyCount: ${practice.practiceNotificationModel?.notifyCount}');
       log('-----------------------------------------');
     }
     notifyListeners();

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -51,7 +51,7 @@ class ProblemPracticeProvider with ChangeNotifier {
         .indexWhere((folder) => practiceNote.practiceId == practiceNoteId);
     if (index != -1) {
       _practices[index] = practiceNote;
-      if(currentPracticeNote != null) {
+      if (currentPracticeNote != null) {
         if (practiceNoteId == currentPracticeNote!.practiceId) {
           await moveToPractice(practiceNoteId);
         }
@@ -77,7 +77,7 @@ class ProblemPracticeProvider with ChangeNotifier {
       log('practiceNotification interval days: ${practice.practiceNotificationModel?.intervalDays}');
       log('practiceNotification hour: ${practice.practiceNotificationModel?.hour}');
       log('practiceNotification minute: ${practice.practiceNotificationModel?.minute}');
-      log('practiceNotification notifyCount: ${practice.practiceNotificationModel?.notifyCount}');
+      log('practiceNotification notifyCount: ${practice.practiceNotificationModel?.weekDays}');
       log('-----------------------------------------');
     }
     notifyListeners();

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -51,8 +51,10 @@ class ProblemPracticeProvider with ChangeNotifier {
         .indexWhere((folder) => practiceNote.practiceId == practiceNoteId);
     if (index != -1) {
       _practices[index] = practiceNote;
-      if (practiceNoteId == currentPracticeNote!.practiceId) {
-        await moveToPractice(practiceNoteId);
+      if(currentPracticeNote != null) {
+        if (practiceNoteId == currentPracticeNote!.practiceId) {
+          await moveToPractice(practiceNoteId);
+        }
       }
     } else {
       _practices.add(practiceNote);
@@ -99,6 +101,7 @@ class ProblemPracticeProvider with ChangeNotifier {
     int createdPracticeId = await practiceNoteService
         .registerPracticeNote(practiceNoteRegisterModel);
 
+    log(createdPracticeId.toString());
     await fetchPracticeNote(createdPracticeId);
   }
 

--- a/lib/Provider/ProblemsProvider.dart
+++ b/lib/Provider/ProblemsProvider.dart
@@ -106,7 +106,10 @@ class ProblemsProvider with ChangeNotifier {
   ) async {
     await problemService
         .registerProblemImageData(problemImageDataRegisterModel);
-    await fetchProblem(problemImageDataRegisterModel.problemId);
+
+    if (problemImageDataRegisterModel.problemId != null) {
+      await fetchProblem(problemImageDataRegisterModel.problemId!);
+    }
 
     log('register problem id: ${problemImageDataRegisterModel.problemId} complete');
     notifyListeners();

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -13,6 +13,7 @@ import 'package:ono/Provider/PracticeNoteProvider.dart';
 import 'package:ono/Service/Api/Problem/ProblemService.dart';
 import 'package:ono/Service/Api/User/UserService.dart';
 import 'package:ono/Service/SocialLogin//KakaoAuthService.dart';
+import 'package:ono/Util/NotificationService.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../Module/Text/StandardText.dart';
@@ -55,6 +56,7 @@ class UserProvider with ChangeNotifier {
       saveUserLoginInfo(userRegisterModel?.platform);
       bool isRegister = await saveUserToken(response: response);
 
+      await NotificationService.instance.sendTokenToServer();
       await fetchAllData();
       LoadingDialog.hide(context);
 

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -75,10 +75,14 @@ class UserProvider with ChangeNotifier {
       LoadingDialog.show(context, '로그인 중 입니다...');
       final response = await userService.signInWithGuest();
 
-      print('user signIn success, response: ${response}');
+      saveUserLoginInfo("GUEST");
       bool isRegister = await saveUserToken(response: response);
 
+      await fetchAllData();
       LoadingDialog.hide(context);
+
+      _loginStatus = LoginStatus.login;
+      notifyListeners();
 
       if (!isRegister) {
         log('register failed!, response: ${response.toString()}');

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -205,6 +205,7 @@ class UserProvider with ChangeNotifier {
       }
     } catch (error) {
       _loginStatus = LoginStatus.logout;
+      notifyListeners();
       throw Exception("자동 로그인 실패, error: ${error.toString()}");
     } finally {
       notifyListeners();

--- a/lib/Screen/Folder/UserGuideScreen.dart
+++ b/lib/Screen/Folder/UserGuideScreen.dart
@@ -67,7 +67,7 @@ class _UserGuideScreenState extends State<UserGuideScreen> {
                 _buildUserGuidePage(
                   imagePath: 'assets/GuideScreen/GuideScreen4.svg',
                   title: '오답 복습',
-                  description: '작성한 오답노트로 복습 리스트를 만들어\n필요한 문제만 빠르게 복습하세요.',
+                  description: '작성한 오답노트로 복습 노트를 만들어\n필요한 문제만 빠르게 복습하세요.',
                 ),
                 _buildUserGuidePage(
                   imagePath: 'assets/GuideScreen/GuideScreen5.svg',

--- a/lib/Screen/PracticeNote/PracticeDetailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeDetailScreen.dart
@@ -89,7 +89,7 @@ class PracticeDetailScreen extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.only(bottom: 20.0), // 타이틀 아래 여백 추가
                   child: StandardText(
-                    text: '복습 리스트 편집하기', // 타이틀 텍스트
+                    text: '복습 노트 편집하기', // 타이틀 텍스트
                     fontSize: 20,
                     color: themeProvider.primaryColor,
                   ),
@@ -99,7 +99,7 @@ class PracticeDetailScreen extends StatelessWidget {
                   child: ListTile(
                     leading: const Icon(Icons.edit, color: Colors.black),
                     title: const StandardText(
-                      text: '문제 목록 편집하기',
+                      text: '복습 노트 편집하기',
                       fontSize: 16,
                       color: Colors.black,
                     ),
@@ -123,7 +123,7 @@ class PracticeDetailScreen extends StatelessWidget {
                     leading:
                         const Icon(Icons.delete_forever, color: Colors.red),
                     title: const StandardText(
-                      text: '복습 리스트 삭제하기',
+                      text: '복습 노트 삭제하기',
                       fontSize: 16,
                       color: Colors.red,
                     ),
@@ -318,7 +318,7 @@ class PracticeDetailScreen extends StatelessWidget {
     } else {
       SnackBarDialog.showSnackBar(
         context: context,
-        message: '복습 리스트가 비어있습니다!',
+        message: '복습 노트가 비어있습니다!',
         backgroundColor: Colors.red,
       );
     }
@@ -333,12 +333,12 @@ class PracticeDetailScreen extends StatelessWidget {
         return AlertDialog(
           backgroundColor: Colors.white,
           title: const StandardText(
-            text: '복습 리스트 삭제',
+            text: '복습 노트 삭제',
             fontSize: 18,
             color: Colors.black,
           ),
           content: const StandardText(
-            text: '정말로 이 복습 리스트를 삭제하시겠습니까?',
+            text: '정말로 이 복습 노트를 삭제하시겠습니까?',
             fontSize: 16,
             color: Colors.black,
           ),

--- a/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
@@ -36,31 +36,27 @@ class _PracticeProblemSelectionScreenState
   @override
   void initState() {
     super.initState();
-    _fetchFolders();
-
-    if (widget.practiceModel != null) {
-      _fetchProblems();
-      _originalProblemIds = widget.practiceModel!.problemIdList;
-    } else {
-      _originalProblemIds = [];
-    }
-  }
-
-  Future<void> _fetchProblems() async {
-    final practiceNoteProvider =
-        Provider.of<ProblemPracticeProvider>(context, listen: false);
-
-    await practiceNoteProvider.moveToPractice(widget.practiceModel!.practiceId);
-    List<ProblemModel> problemModelList = practiceNoteProvider.currentProblems;
-
-    setState(() {
-      selectedProblems = problemModelList;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _fetchFolders();
+      if (widget.practiceModel != null) {
+        _originalProblemIds = widget.practiceModel!.problemIdList;
+        _fetchProblems();
+      } else {
+        _originalProblemIds = [];
+      }
     });
   }
 
+  Future<void> _fetchProblems() async {
+    final practiceNoteProvider = context.read<ProblemPracticeProvider>();
+
+    await practiceNoteProvider.moveToPractice(widget.practiceModel!.practiceId);
+    final problemModelList = practiceNoteProvider.currentProblems;
+    setState(() => selectedProblems = problemModelList);
+  }
+
   Future<void> _fetchFolders() async {
-    final foldersProvider =
-        Provider.of<FoldersProvider>(context, listen: false);
+    final foldersProvider = context.read<FoldersProvider>();
 
     List<FolderModel> folders = foldersProvider.folders;
 
@@ -336,6 +332,7 @@ class _PracticeProblemSelectionScreenState
                     MaterialPageRoute(
                       builder: (context) => PracticeTitleWriteScreen(
                         practiceNoteUpdateModel: updateModel,
+                        practiceNoteDetailModel: widget.practiceModel!,
                       ),
                     ),
                   );

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -288,10 +288,13 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                   _selectedPracticeIds.clear();
                 });
 
-                SnackBarDialog.showSnackBar(
+                Future.delayed(Duration.zero, () {
+                  SnackBarDialog.showSnackBar(
                     context: context,
                     message: '복습 노트가 삭제되었습니다!',
-                    backgroundColor: themeProvider.primaryColor);
+                    backgroundColor: themeProvider.primaryColor,
+                  );
+                });
               },
               child: const StandardText(
                 text: '삭제',

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -278,14 +278,15 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
             TextButton(
               onPressed: () async {
                 Navigator.pop(context);
-                setState(() {
-                  _isSelectionMode = false;
-                  _selectedPracticeIds.clear();
-                });
 
                 final provider = Provider.of<ProblemPracticeProvider>(context,
                     listen: false);
                 await provider.deletePractices(deletePracticeIds);
+
+                setState(() {
+                  _isSelectionMode = false;
+                  _selectedPracticeIds.clear();
+                });
 
                 SnackBarDialog.showSnackBar(
                     context: context,

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -26,7 +26,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
   @override
   void initState() {
     super.initState();
-    //_fetchAllPracticeContents();
+    _fetchAllPracticeContents();
   }
 
   Future<void> _fetchAllPracticeContents() async {

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -121,7 +121,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                 Padding(
                   padding: const EdgeInsets.only(bottom: 20.0), // 타이틀 아래 여백 추가
                   child: StandardText(
-                    text: '복습 리스트 편집하기', // 타이틀 텍스트
+                    text: '복습 노트 편집하기', // 타이틀 텍스트
                     fontSize: 20,
                     color: themeProvider.primaryColor,
                   ),
@@ -131,7 +131,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                   child: ListTile(
                     leading: const Icon(Icons.add, color: Colors.black),
                     title: const StandardText(
-                      text: '복습 리스트 생성하기',
+                      text: '복습 노트 생성하기',
                       fontSize: 16,
                       color: Colors.black,
                     ),
@@ -154,7 +154,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                     leading:
                         const Icon(Icons.delete_forever, color: Colors.red),
                     title: const StandardText(
-                      text: '복습 리스트 삭제하기',
+                      text: '복습 노트 삭제하기',
                       fontSize: 16,
                       color: Colors.red,
                     ),
@@ -255,12 +255,12 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
         return AlertDialog(
           backgroundColor: Colors.white,
           title: const StandardText(
-            text: '복습 리스트 삭제',
+            text: '복습 노트 삭제',
             fontSize: 18,
             color: Colors.black,
           ),
           content: const StandardText(
-            text: '정말로 이 복습 리스트를 삭제하시겠습니까?',
+            text: '정말로 이 복습 노트를 삭제하시겠습니까?',
             fontSize: 16,
             color: Colors.black,
           ),
@@ -289,7 +289,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
 
                 SnackBarDialog.showSnackBar(
                     context: context,
-                    message: '복습 리스트가 삭제되었습니다!',
+                    message: '복습 노트가 삭제되었습니다!',
                     backgroundColor: themeProvider.primaryColor);
               },
               child: const StandardText(
@@ -321,7 +321,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
           ),
           const SizedBox(height: 40),
           const StandardText(
-            text: '작성한 오답노트로 복습 리스트를\n 생성해 시험을 준비하세요!',
+            text: '작성한 오답노트로 복습 노트를\n 생성해 시험을 준비하세요!',
             fontSize: 16,
             color: Colors.black,
             textAlign: TextAlign.center,
@@ -329,7 +329,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
           const SizedBox(height: 30),
           ElevatedButton(
             onPressed: () {
-              // 복습 리스트 추가 화면으로 이동
+              // 복습 노트 추가 화면으로 이동
               Navigator.push(
                 context,
                 MaterialPageRoute(
@@ -348,7 +348,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
               ),
             ),
             child: const StandardText(
-              text: '복습 리스트 추가하기',
+              text: '복습 노트 추가하기',
               fontSize: 16,
               color: Colors.white,
             ),
@@ -408,7 +408,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
   void _navigateToPracticeDetail(PracticeNoteDetailModel practice) async {
     final practiceProvider =
         Provider.of<ProblemPracticeProvider>(context, listen: false);
-    LoadingDialog.show(context, '복습 리스트 로딩 중...');
+    LoadingDialog.show(context, '복습 노트 로딩 중...');
 
     await practiceProvider.moveToPractice(practice.practiceId);
     LoadingDialog.hide(context);

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ono/Model/PracticeNote/PracticeNoteUpdateModel.dart';
@@ -286,54 +287,140 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
   }
 
   Widget _buildNotificationSection(ThemeHandler theme, double screenHeight) {
-    return Column(
-      children: [
-        SwitchListTile(
-          title: StandardText(
-            text: '복습 주기 알림 사용',
-            fontSize: 16,
-            color: theme.primaryColor,
-          ),
-          value: _notifyEnabled,
-          onChanged: (v) => setState(() => _notifyEnabled = v),
-        ),
-        if (_notifyEnabled) ...[
-          SizedBox(height: screenHeight * 0.02),
-          _buildNumberInput(
-            label: '알림 주기(일)',
-            value: _intervalDays,
-            onChanged: (v) => setState(() => _intervalDays = v),
-            themeProvider: theme,
-          ),
-          SizedBox(height: screenHeight * 0.02),
-          ListTile(
-            title: const StandardText(
-              text: '알림 시각',
-              fontSize: 16,
-              color: Colors.black,
-            ),
-            trailing: StandardText(
-              text: _notifyTime.format(context),
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0), // 좌우 여백
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 2) 스위치 색깔 변경: activeColor
+          SwitchListTile(
+            title: StandardText(
+              text: '복습 주기 알림 사용',
               fontSize: 16,
               color: theme.primaryColor,
             ),
-            onTap: () async {
-              final t = await showTimePicker(
-                context: context,
-                initialTime: _notifyTime,
-              );
-              if (t != null) setState(() => _notifyTime = t);
-            },
+            value: _notifyEnabled,
+            activeColor: theme.primaryColor, // 토글 색
+            onChanged: (v) => setState(() => _notifyEnabled = v),
           ),
-          SizedBox(height: screenHeight * 0.02),
-          _buildNumberInput(
-            label: '알림 횟수',
-            value: _notifyCount,
-            onChanged: (v) => setState(() => _notifyCount = v),
-            themeProvider: theme,
-          ),
+
+          if (_notifyEnabled) ...[
+            SizedBox(height: screenHeight * 0.02),
+
+            // 3) 숫자 입력도 동일한 패딩 Row로
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4.0),
+              child: _buildNumberInput(
+                label: '알림 주기(일)',
+                value: _intervalDays,
+                onChanged: (v) => setState(() => _intervalDays = v),
+                themeProvider: theme,
+              ),
+            ),
+
+            SizedBox(height: screenHeight * 0.02),
+
+            // 4) 시간 선택: BottomSheet + CupertinoDatePicker
+            GestureDetector(
+              onTap: () => _showTimePickerBottomSheet(context),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const StandardText(
+                      text: '알림 시각',
+                      fontSize: 16,
+                      color: Colors.black,
+                    ),
+                    StandardText(
+                      text: _notifyTime.format(context),
+                      fontSize: 16,
+                      color: theme.primaryColor,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            SizedBox(height: screenHeight * 0.02),
+
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4.0),
+              child: _buildNumberInput(
+                label: '알림 횟수',
+                value: _notifyCount,
+                onChanged: (v) => setState(() => _notifyCount = v),
+                themeProvider: theme,
+              ),
+            ),
+          ],
         ],
-      ],
+      ),
+    );
+  }
+
+  void _showTimePickerBottomSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.white, // 바텀시트 배경을 흰색으로
+      shape: const RoundedRectangleBorder(
+        // 모서리를 살짝 둥글게
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (_) {
+        return Container(
+          height: 250,
+          padding: const EdgeInsets.all(16),
+          decoration: const BoxDecoration(
+            color: Colors.white, // 내부도 확실히 흰색
+            borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+          ),
+          child: Column(
+            children: [
+              const StandardText(
+                text: '알림 시각 선택',
+                color: Colors.black,
+                fontSize: 18,
+              ),
+              const SizedBox(
+                height: 20,
+              ),
+              Expanded(
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.time,
+                  initialDateTime: DateTime(
+                    0,
+                    0,
+                    0,
+                    _notifyTime.hour,
+                    _notifyTime.minute,
+                  ),
+                  use24hFormat: false,
+                  onDateTimeChanged: (dt) {
+                    setState(() {
+                      _notifyTime = TimeOfDay(
+                        hour: dt.hour,
+                        minute: dt.minute,
+                      );
+                    });
+                  },
+                ),
+              ),
+              const SizedBox(
+                height: 20,
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const StandardText(
+                  text: '확인',
+                  color: Colors.black,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -205,7 +205,8 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           borderRadius: BorderRadius.circular(10),
           borderSide: BorderSide(color: themeProvider.primaryColor, width: 2.0),
         ),
-        fillColor: themeProvider.primaryColor.withOpacity(0.1),
+        fillColor: Colors.white,
+        //fillColor: themeProvider.primaryColor.withOpacity(0.1),
         filled: true,
         hintText: "ex) 9월 모의 전과목 모의고사 오답 복습",
         hintStyle: standardTextStyle.copyWith(
@@ -288,28 +289,48 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
 
   Widget _buildNotificationSection(ThemeHandler theme, double screenHeight) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0), // 좌우 여백
+      margin: const EdgeInsets.symmetric(vertical: 12.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: theme.primaryColor, width: 2.0),
+        borderRadius: BorderRadius.circular(10),
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 2) 스위치 색깔 변경: activeColor
-          SwitchListTile(
-            title: StandardText(
-              text: '복습 주기 알림 사용',
-              fontSize: 16,
-              color: theme.primaryColor,
+          // 공통 좌우 패딩
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 10, 8, 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                StandardText(
+                  text: '복습 주기 알림 사용',
+                  fontSize: 16,
+                  color: theme.primaryColor,
+                ),
+                // 스위치 크기 줄이기
+                Transform.scale(
+                  scale: 0.8, // 80% 크기로 축소
+                  child: Switch(
+                    value: _notifyEnabled,
+                    activeColor: theme.darkPrimaryColor,
+                    inactiveTrackColor: Colors.grey.shade300,
+                    inactiveThumbColor: Colors.grey,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    onChanged: (v) => setState(() => _notifyEnabled = v),
+                  ),
+                ),
+              ],
             ),
-            value: _notifyEnabled,
-            activeColor: theme.primaryColor, // 토글 색
-            onChanged: (v) => setState(() => _notifyEnabled = v),
           ),
 
           if (_notifyEnabled) ...[
             SizedBox(height: screenHeight * 0.02),
 
-            // 3) 숫자 입력도 동일한 패딩 Row로
+            // 알림 주기
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4.0),
+              padding: const EdgeInsets.fromLTRB(16.0, 0, 0, 0),
               child: _buildNumberInput(
                 label: '알림 주기(일)',
                 value: _intervalDays,
@@ -320,23 +341,20 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
 
             SizedBox(height: screenHeight * 0.02),
 
-            // 4) 시간 선택: BottomSheet + CupertinoDatePicker
-            GestureDetector(
-              onTap: () => _showTimePickerBottomSheet(context),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 4.0),
+            // 알림 시각
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: GestureDetector(
+                onTap: () => _showTimePickerBottomSheet(context),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    const StandardText(
-                      text: '알림 시각',
-                      fontSize: 16,
-                      color: Colors.black,
-                    ),
+                    StandardText(
+                        text: '알림 시각', fontSize: 16, color: theme.primaryColor),
                     StandardText(
                       text: _notifyTime.format(context),
                       fontSize: 16,
-                      color: theme.primaryColor,
+                      color: Colors.black,
                     ),
                   ],
                 ),
@@ -345,8 +363,9 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
 
             SizedBox(height: screenHeight * 0.02),
 
+            // 알림 횟수
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4.0),
+              padding: const EdgeInsets.fromLTRB(16.0, 0, 0, 0),
               child: _buildNumberInput(
                 label: '알림 횟수',
                 value: _notifyCount,
@@ -354,6 +373,8 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
                 themeProvider: theme,
               ),
             ),
+
+            SizedBox(height: screenHeight * 0.02),
           ],
         ],
       ),
@@ -430,28 +451,35 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
     required ValueChanged<int> onChanged,
     required ThemeHandler themeProvider,
   }) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        StandardText(text: label, fontSize: 16, color: Colors.black),
-        Row(
-          children: [
-            IconButton(
-              icon: Icon(Icons.remove, color: themeProvider.primaryColor),
-              onPressed: value > 1 ? () => onChanged(value - 1) : null,
-            ),
-            StandardText(
-              text: '$value',
-              fontSize: 16,
-              color: themeProvider.primaryColor,
-            ),
-            IconButton(
-              icon: Icon(Icons.add, color: themeProvider.primaryColor),
-              onPressed: () => onChanged(value + 1),
-            ),
-          ],
-        ),
-      ],
+    return SizedBox(
+      width: double.infinity, // 폭을 최대한으로 늘립니다.
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween, // 양 끝 정렬
+        children: [
+          StandardText(
+            text: label,
+            fontSize: 16,
+            color: themeProvider.primaryColor,
+          ),
+          Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.remove, color: Colors.black),
+                onPressed: value > 1 ? () => onChanged(value - 1) : null,
+              ),
+              StandardText(
+                text: '$value',
+                fontSize: 16,
+                color: Colors.black,
+              ),
+              IconButton(
+                icon: const Icon(Icons.add, color: Colors.black),
+                onPressed: () => onChanged(value + 1),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -9,6 +9,7 @@ import 'package:ono/Model/PracticeNote/PracticeNotificationModel.dart';
 import 'package:provider/provider.dart';
 
 import '../../Model/PracticeNote/PracticeNoteRegisterModel.dart';
+import '../../Model/PracticeNote/RepeatType.dart';
 import '../../Module/Dialog/SnackBarDialog.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
@@ -36,7 +37,8 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
   bool _notifyEnabled = false;
   int _intervalDays = 7;
   TimeOfDay _notifyTime = const TimeOfDay(hour: 18, minute: 0);
-  int _notifyCount = 3;
+  RepeatType _repeatType = RepeatType.daily;
+  Set<int> _selectedWeekdays = {};
 
   @override
   void initState() {
@@ -56,9 +58,13 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           widget.practiceNoteDetailModel!.practiceNotificationModel!.hour!;
       final minute =
           widget.practiceNoteDetailModel!.practiceNotificationModel!.minute!;
+      _repeatType = widget
+          .practiceNoteDetailModel!.practiceNotificationModel!.repeatType!;
+      _selectedWeekdays = widget
+          .practiceNoteDetailModel!.practiceNotificationModel!.weekDays!
+          .toSet();
+
       _notifyTime = TimeOfDay(hour: hour, minute: minute);
-      _notifyCount = widget
-          .practiceNoteDetailModel!.practiceNotificationModel!.notifyCount!;
     }
   }
 
@@ -87,7 +93,10 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               intervalDays: _intervalDays,
               hour: _notifyTime.hour,
               minute: _notifyTime.minute,
-              notifyCount: _notifyCount,
+              repeatType: _repeatType,
+              weekDays: _repeatType == RepeatType.weekly
+                  ? _selectedWeekdays.toList()
+                  : null,
             );
 
             widget.practiceNoteUpdateModel!
@@ -112,7 +121,10 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               intervalDays: _intervalDays,
               hour: _notifyTime.hour,
               minute: _notifyTime.minute,
-              notifyCount: _notifyCount,
+              repeatType: _repeatType,
+              weekDays: _repeatType == RepeatType.weekly
+                  ? _selectedWeekdays.toList()
+                  : null,
             );
 
             widget.practiceRegisterModel!
@@ -378,16 +390,53 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           if (_notifyEnabled) ...[
             SizedBox(height: screenHeight * 0.02),
 
-            // 알림 주기
             Padding(
-              padding: const EdgeInsets.fromLTRB(16.0, 0, 0, 0),
-              child: _buildNumberInput(
-                label: '알림 주기(일)',
-                value: _intervalDays,
-                onChanged: (v) => setState(() => _intervalDays = v),
-                themeProvider: theme,
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Row(
+                children: [
+                  ChoiceChip(
+                    label: StandardText(text: "매일"),
+                    selected: _repeatType == RepeatType.daily,
+                    onSelected: (_) =>
+                        setState(() => _repeatType = RepeatType.daily),
+                  ),
+                  const SizedBox(width: 10),
+                  ChoiceChip(
+                    label: StandardText(text: "매주"),
+                    selected: _repeatType == RepeatType.weekly,
+                    onSelected: (_) =>
+                        setState(() => _repeatType = RepeatType.weekly),
+                  ),
+                ],
               ),
             ),
+
+            SizedBox(height: screenHeight * 0.02),
+            // 요일 선택 (매주인 경우만)
+            if (_repeatType == RepeatType.weekly)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: Wrap(
+                  spacing: 6,
+                  children: List.generate(7, (index) {
+                    final day = index + 1; // 1 = 월 ~ 7 = 일
+                    final dayText = ['월', '화', '수', '목', '금', '토', '일'][index];
+                    return FilterChip(
+                      label: Text(dayText),
+                      selected: _selectedWeekdays.contains(day),
+                      onSelected: (bool selected) {
+                        setState(() {
+                          if (selected) {
+                            _selectedWeekdays.add(day);
+                          } else {
+                            _selectedWeekdays.remove(day);
+                          }
+                        });
+                      },
+                    );
+                  }),
+                ),
+              ),
 
             SizedBox(height: screenHeight * 0.02),
 
@@ -408,19 +457,6 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
                     ),
                   ],
                 ),
-              ),
-            ),
-
-            SizedBox(height: screenHeight * 0.02),
-
-            // 알림 횟수
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16.0, 0, 0, 0),
-              child: _buildNumberInput(
-                label: '알림 횟수',
-                value: _notifyCount,
-                onChanged: (v) => setState(() => _notifyCount = v),
-                themeProvider: theme,
               ),
             ),
 

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -424,7 +424,10 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
                     final day = index + 1; // 1 = 월 ~ 7 = 일
                     final dayText = ['월', '화', '수', '목', '금', '토', '일'][index];
                     return FilterChip(
-                      label: Text(dayText),
+                      label: StandardText(
+                        text: dayText,
+                        fontSize: 13,
+                      ),
                       selected: _selectedWeekdays.contains(day),
                       onSelected: (bool selected) {
                         setState(() {

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -28,8 +28,8 @@ class PracticeTitleWriteScreen extends StatefulWidget {
 class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
   late TextEditingController _titleController;
   bool _notifyEnabled = false;
-  int _intervalDays = 1;
-  TimeOfDay _notifyTime = TimeOfDay(hour: 9, minute: 0);
+  int _intervalDays = 7;
+  TimeOfDay _notifyTime = const TimeOfDay(hour: 18, minute: 0);
   int _notifyCount = 3;
 
   @override

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -74,9 +76,6 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
       final problemPracticeProvider =
           Provider.of<ProblemPracticeProvider>(context, listen: false);
 
-      Navigator.pop(context);
-      Navigator.pop(context);
-
       try {
         if (widget.practiceNoteUpdateModel != null) {
           widget.practiceNoteUpdateModel!
@@ -98,9 +97,12 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           await problemPracticeProvider
               .updatePractice(widget.practiceNoteUpdateModel!);
 
-          Navigator.pop(context);
           _showSnackBar(context, themeProvider, '복습 노트가 수정되었습니다.',
               themeProvider.primaryColor);
+
+          Navigator.pop(context);
+          Navigator.pop(context);
+          Navigator.pop(context);
         } else {
           widget.practiceRegisterModel!.setPracticeTitle(_titleController.text);
 
@@ -121,9 +123,14 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
 
           _showSnackBar(context, themeProvider, '복습 노트가 생성되었습니다.',
               themeProvider.primaryColor);
+
+          Navigator.pop(context);
+          Navigator.pop(context);
         }
       } catch (error) {
+        log(error.toString());
         _showSnackBar(context, themeProvider, '복습 노트 생성에 실패했습니다.', Colors.red);
+        throw Exception(error);
       }
     }
   }

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:ono/Model/PracticeNote/PracticeNoteDetailModel.dart';
 import 'package:ono/Model/PracticeNote/PracticeNoteUpdateModel.dart';
 import 'package:ono/Model/PracticeNote/PracticeNotificationModel.dart';
 import 'package:provider/provider.dart';
@@ -14,11 +15,13 @@ import '../../Provider/PracticeNoteProvider.dart';
 class PracticeTitleWriteScreen extends StatefulWidget {
   final PracticeNoteRegisterModel? practiceRegisterModel;
   final PracticeNoteUpdateModel? practiceNoteUpdateModel;
+  final PracticeNoteDetailModel? practiceNoteDetailModel;
 
   const PracticeTitleWriteScreen({
     super.key,
     this.practiceRegisterModel,
     this.practiceNoteUpdateModel,
+    this.practiceNoteDetailModel,
   });
 
   @override
@@ -41,7 +44,20 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           ? widget.practiceNoteUpdateModel!.practiceTitle
           : widget.practiceRegisterModel?.practiceTitle ?? '',
     );
-    // 초기 설정: 만약 모델에 알림 설정이 이미 있으면, 여기에 반영하세요.
+
+    if (widget.practiceNoteDetailModel != null &&
+        widget.practiceNoteDetailModel!.practiceNotificationModel != null) {
+      _notifyEnabled = true;
+      _intervalDays = widget
+          .practiceNoteDetailModel!.practiceNotificationModel!.intervalDays!;
+      final hour =
+          widget.practiceNoteDetailModel!.practiceNotificationModel!.hour!;
+      final minute =
+          widget.practiceNoteDetailModel!.practiceNotificationModel!.minute!;
+      _notifyTime = TimeOfDay(hour: hour, minute: minute);
+      _notifyCount = widget
+          .practiceNoteDetailModel!.practiceNotificationModel!.notifyCount!;
+    }
   }
 
   @override
@@ -65,6 +81,20 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
         if (widget.practiceNoteUpdateModel != null) {
           widget.practiceNoteUpdateModel!
               .setPracticeTitle(_titleController.text);
+
+          if (_notifyEnabled) {
+            PracticeNotificationModel practiceNotificationModel =
+                PracticeNotificationModel(
+              intervalDays: _intervalDays,
+              hour: _notifyTime.hour,
+              minute: _notifyTime.minute,
+              notifyCount: _notifyCount,
+            );
+
+            widget.practiceNoteUpdateModel!
+                .setPracticeNotificationModel(practiceNotificationModel);
+          }
+
           await problemPracticeProvider
               .updatePractice(widget.practiceNoteUpdateModel!);
 

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -58,13 +58,15 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           widget.practiceNoteDetailModel!.practiceNotificationModel!.hour!;
       final minute =
           widget.practiceNoteDetailModel!.practiceNotificationModel!.minute!;
-      _repeatType = widget
-          .practiceNoteDetailModel!.practiceNotificationModel!.repeatType!;
-      _selectedWeekdays = widget
-          .practiceNoteDetailModel!.practiceNotificationModel!.weekDays!
-          .toSet();
-
       _notifyTime = TimeOfDay(hour: hour, minute: minute);
+
+      _repeatType = widget
+              .practiceNoteDetailModel!.practiceNotificationModel!.repeatType ??
+          RepeatType.daily;
+      _selectedWeekdays = widget
+              .practiceNoteDetailModel!.practiceNotificationModel!.weekDays
+              ?.toSet() ??
+          Set();
     }
   }
 

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -69,7 +69,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               .updatePractice(widget.practiceNoteUpdateModel!);
 
           Navigator.pop(context);
-          _showSnackBar(context, themeProvider, '복습 리스트가 수정되었습니다.',
+          _showSnackBar(context, themeProvider, '복습 노트가 수정되었습니다.',
               themeProvider.primaryColor);
         } else {
           widget.practiceRegisterModel!.setPracticeTitle(_titleController.text);
@@ -89,11 +89,11 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           await problemPracticeProvider
               .registerPractice(widget.practiceRegisterModel!);
 
-          _showSnackBar(context, themeProvider, '복습 리스트가 생성되었습니다.',
+          _showSnackBar(context, themeProvider, '복습 노트가 생성되었습니다.',
               themeProvider.primaryColor);
         }
       } catch (error) {
-        _showSnackBar(context, themeProvider, '복습 리스트 생성에 실패했습니다.', Colors.red);
+        _showSnackBar(context, themeProvider, '복습 노트 생성에 실패했습니다.', Colors.red);
       }
     }
   }
@@ -158,9 +158,8 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
   AppBar _buildAppBar(ThemeHandler themeProvider) {
     return AppBar(
       title: StandardText(
-        text: widget.practiceNoteUpdateModel == null
-            ? "복습 리스트 만들기"
-            : "복습 리스트 수정하기",
+        text:
+            widget.practiceNoteUpdateModel == null ? "복습 노트 만들기" : "복습 노트 수정하기",
         fontSize: 20,
         color: themeProvider.primaryColor,
       ),
@@ -191,7 +190,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
   Widget _buildTitleText() {
     return StandardText(
       text: widget.practiceNoteUpdateModel == null
-          ? "복습 리스트의 이름을 입력해주세요"
+          ? "복습 노트의 이름을 입력해주세요"
           : "수정할 이름을 입력해주세요",
       fontSize: 18,
       color: Colors.black,
@@ -291,8 +290,8 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           ),
           child: StandardText(
             text: widget.practiceRegisterModel == null
-                ? "복습 리스트 수정하기"
-                : "복습 리스트 만들기",
+                ? "복습 노트 수정하기"
+                : "복습 노트 만들기",
             fontSize: 18,
             color: Colors.white,
           ),

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ono/Model/PracticeNote/PracticeNoteUpdateModel.dart';
+import 'package:ono/Model/PracticeNote/PracticeNotificationModel.dart';
 import 'package:provider/provider.dart';
 
 import '../../Model/PracticeNote/PracticeNoteRegisterModel.dart';
@@ -72,6 +73,19 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               themeProvider.primaryColor);
         } else {
           widget.practiceRegisterModel!.setPracticeTitle(_titleController.text);
+
+          if (_notifyEnabled) {
+            PracticeNotificationModel practiceNotificationModel =
+                PracticeNotificationModel(
+              intervalDays: _intervalDays,
+              hour: _notifyTime.hour,
+              minute: _notifyTime.minute,
+              notifyCount: _notifyCount,
+            );
+
+            widget.practiceRegisterModel!
+                .setPracticeNotificationModel(practiceNotificationModel);
+          }
           await problemPracticeProvider
               .registerPractice(widget.practiceRegisterModel!);
 
@@ -79,7 +93,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               themeProvider.primaryColor);
         }
       } catch (error) {
-        _showSnackBar(context, themeProvider, '복습 리스트가 실패했습니다.', Colors.red);
+        _showSnackBar(context, themeProvider, '복습 리스트 생성에 실패했습니다.', Colors.red);
       }
     }
   }

--- a/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
@@ -1,9 +1,10 @@
+import 'dart:developer';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:ono/Module/Text/StandardText.dart';
 import 'package:provider/provider.dart';
 
-import '../../Model/Common/LoginStatus.dart';
 import '../../Model/Common/ProblemImageDataType.dart';
 import '../../Model/Problem/ProblemImageDataRegisterModel.dart';
 import '../../Model/Problem/ProblemModel.dart';
@@ -16,7 +17,6 @@ import '../../Module/Util/FolderPickerWidget.dart';
 import '../../Provider/FoldersProvider.dart';
 import '../../Provider/ProblemsProvider.dart';
 import '../../Provider/ScreenIndexProvider.dart';
-import '../../Provider/UserProvider.dart';
 import '../../Service/Api/FileUpload/FileUploadService.dart';
 import 'Widget/ActionButtons.dart';
 import 'Widget/DatePickerWidget.dart';
@@ -74,85 +74,92 @@ class _ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
   Widget build(BuildContext context) {
     final isWide = MediaQuery.of(context).size.width >= 600;
 
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          DatePickerWidget(
-            selectedDate: _selectedDate,
-            onDateChanged: (d) => setState(() => _selectedDate = d),
-          ),
-          const SizedBox(height: 30),
-          FolderPickerWidget(
-            selectedId: _selectedFolderId,
-            onPicked: (id) => setState(() => _selectedFolderId = id),
-          ),
-          const SizedBox(height: 30),
-          LabeledTextField(
-            label: '제목',
-            hintText: '오답노트의 제목을 작성해주세요!',
-            icon: Icons.info,
-            controller: _titleCtrl,
-          ),
-          const SizedBox(height: 30),
-          LabeledTextField(
-            label: '메모',
-            controller: _memoCtrl,
-            icon: Icons.edit,
-            hintText: '기록하고 싶은 내용을 간단하게 작성해주세요!',
-            maxLines: 3,
-          ),
-          const SizedBox(height: 30),
-          if (isWide)
-            Row(
-              children: [
-                Expanded(
-                  child: ImageGridWidget(
-                    label: '문제 이미지',
-                    files: _problemImages,
-                    onAdd: _pickProblemImage,
-                    onRemove: (i) => setState(() => _problemImages.removeAt(i)),
-                  ),
+    return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              DatePickerWidget(
+                selectedDate: _selectedDate,
+                onDateChanged: (d) => setState(() => _selectedDate = d),
+              ),
+              const SizedBox(height: 30),
+              FolderPickerWidget(
+                selectedId: _selectedFolderId,
+                onPicked: (id) => setState(() => _selectedFolderId = id),
+              ),
+              const SizedBox(height: 30),
+              LabeledTextField(
+                label: '제목',
+                hintText: '오답노트의 제목을 작성해주세요!',
+                icon: Icons.info,
+                controller: _titleCtrl,
+              ),
+              const SizedBox(height: 30),
+              LabeledTextField(
+                label: '메모',
+                controller: _memoCtrl,
+                icon: Icons.edit,
+                hintText: '기록하고 싶은 내용을 간단하게 작성해주세요!',
+                maxLines: 3,
+              ),
+              const SizedBox(height: 30),
+              if (isWide)
+                Row(
+                  children: [
+                    Expanded(
+                      child: ImageGridWidget(
+                        label: '문제 이미지',
+                        files: _problemImages,
+                        onAdd: _pickProblemImage,
+                        onRemove: (i) =>
+                            setState(() => _problemImages.removeAt(i)),
+                      ),
+                    ),
+                    const SizedBox(width: 30),
+                    Expanded(
+                      child: ImageGridWidget(
+                        label: '해설 이미지',
+                        files: _answerImages,
+                        onAdd: _pickAnswerImage,
+                        onRemove: (i) =>
+                            setState(() => _answerImages.removeAt(i)),
+                      ),
+                    ),
+                  ],
+                )
+              else
+                Column(
+                  children: [
+                    ImageGridWidget(
+                      label: '문제 이미지',
+                      files: _problemImages,
+                      onAdd: _pickProblemImage,
+                      onRemove: (i) =>
+                          setState(() => _problemImages.removeAt(i)),
+                    ),
+                    const SizedBox(height: 30),
+                    ImageGridWidget(
+                      label: '해설 이미지',
+                      files: _answerImages,
+                      onAdd: _pickAnswerImage,
+                      onRemove: (i) =>
+                          setState(() => _answerImages.removeAt(i)),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 30),
-                Expanded(
-                  child: ImageGridWidget(
-                    label: '해설 이미지',
-                    files: _answerImages,
-                    onAdd: _pickAnswerImage,
-                    onRemove: (i) => setState(() => _answerImages.removeAt(i)),
-                  ),
-                ),
-              ],
-            )
-          else
-            Column(
-              children: [
-                ImageGridWidget(
-                  label: '문제 이미지',
-                  files: _problemImages,
-                  onAdd: _pickProblemImage,
-                  onRemove: (i) => setState(() => _problemImages.removeAt(i)),
-                ),
-                const SizedBox(height: 30),
-                ImageGridWidget(
-                  label: '해설 이미지',
-                  files: _answerImages,
-                  onAdd: _pickAnswerImage,
-                  onRemove: (i) => setState(() => _answerImages.removeAt(i)),
-                ),
-              ],
-            ),
-          const SizedBox(height: 30),
-          ActionButtons(
-            isEdit: widget.isEditMode,
-            onCancel: _resetAll,
-            onSubmit: _submit,
+              const SizedBox(height: 30),
+              ActionButtons(
+                isEdit: widget.isEditMode,
+                onCancel: _resetAll,
+                onSubmit: _submit,
+              ),
+              const SizedBox(height: 10),
+            ],
           ),
-          const SizedBox(height: 10),
-        ],
-      ),
-    );
+        ));
   }
 
   Future<void> _pickProblemImage() async {
@@ -190,21 +197,25 @@ class _ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
           await service.uploadMultipleImageFiles(_problemImages);
       final answerImageUrlList =
           await service.uploadMultipleImageFiles(_answerImages);
-      final now = DateTime.now();
-      final imageDataList = [
-        for (var imageUrl in problemImageUrlList)
-          ProblemImageDataRegisterModel(
-            problemId: widget.problemModel!.problemId,
-            imageUrl: imageUrl,
-            problemImageType: ProblemImageType.PROBLEM_IMAGE,
-          ),
-        for (var imageUrl in answerImageUrlList)
-          ProblemImageDataRegisterModel(
-            problemId: widget.problemModel!.problemId,
-            imageUrl: imageUrl,
-            problemImageType: ProblemImageType.ANSWER_IMAGE,
-          ),
-      ];
+
+      final List<ProblemImageDataRegisterModel> imageDataList = [];
+      for (var imageUrl in problemImageUrlList) {
+        final problemImageDataRegisterModel = ProblemImageDataRegisterModel(
+          problemId: widget.problemModel?.problemId,
+          imageUrl: imageUrl,
+          problemImageType: ProblemImageType.PROBLEM_IMAGE,
+        );
+        imageDataList.add(problemImageDataRegisterModel);
+      }
+
+      for (var imageUrl in answerImageUrlList) {
+        final answerImageDataRegisterModel = ProblemImageDataRegisterModel(
+          problemId: widget.problemModel?.problemId,
+          imageUrl: imageUrl,
+          problemImageType: ProblemImageType.ANSWER_IMAGE,
+        );
+        imageDataList.add(answerImageDataRegisterModel);
+      }
 
       final problemRegisterModel = ProblemRegisterModel(
         problemId: widget.problemModel?.problemId,
@@ -214,12 +225,6 @@ class _ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
         folderId: _selectedFolderId,
         imageDataDtoList: imageDataList,
       );
-
-      final authService = Provider.of<UserProvider>(context, listen: false);
-      if (authService.isLoggedIn == LoginStatus.logout) {
-        _showLoginRequiredDialog(context);
-        return;
-      }
 
       if (widget.isEditMode) {
         await Provider.of<ProblemsProvider>(context, listen: false)
@@ -249,8 +254,10 @@ class _ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
       }
 
       showSuccessDialog(context);
-    } catch (_) {
-      //…
+    } catch (e, stackTrace) {
+      log('오답노트 등록 실패: $e');
+      log(stackTrace.toString());
+      throw Exception(e);
     } finally {
       LoadingDialog.hide(context);
     }

--- a/lib/Service/Api/FileUpload/FileUploadService.dart
+++ b/lib/Service/Api/FileUpload/FileUploadService.dart
@@ -34,7 +34,7 @@ class FileUploadService {
         files: multipartFiles,
       );
 
-      return List<String>.from(data as List);
+      return List<String>.from(data);
     } else {
       return [];
     }

--- a/lib/Service/Api/PracticeNote/PracticeNoteService.dart
+++ b/lib/Service/Api/PracticeNote/PracticeNoteService.dart
@@ -43,6 +43,9 @@ class PracticeNoteService {
 
   Future<int> registerPracticeNote(
       PracticeNoteRegisterModel practiceNoteRegisterModel) async {
+    await httpService.sendRequest(
+        method: "POST", url: "${AppConfig.baseUrl}/api/fcm/send");
+
     return await httpService.sendRequest(
       method: 'POST',
       url: baseUrl,

--- a/lib/Service/Api/PracticeNote/PracticeNoteService.dart
+++ b/lib/Service/Api/PracticeNote/PracticeNoteService.dart
@@ -43,12 +43,6 @@ class PracticeNoteService {
 
   Future<int> registerPracticeNote(
       PracticeNoteRegisterModel practiceNoteRegisterModel) async {
-    /*
-    await httpService.sendRequest(
-        method: "POST", url: "${AppConfig.baseUrl}/api/fcm/send");
-
-     */
-
     return await httpService.sendRequest(
       method: 'POST',
       url: baseUrl,

--- a/lib/Service/Api/PracticeNote/PracticeNoteService.dart
+++ b/lib/Service/Api/PracticeNote/PracticeNoteService.dart
@@ -43,8 +43,11 @@ class PracticeNoteService {
 
   Future<int> registerPracticeNote(
       PracticeNoteRegisterModel practiceNoteRegisterModel) async {
+    /*
     await httpService.sendRequest(
         method: "POST", url: "${AppConfig.baseUrl}/api/fcm/send");
+
+     */
 
     return await httpService.sendRequest(
       method: 'POST',

--- a/lib/Service/Api/User/UserService.dart
+++ b/lib/Service/Api/User/UserService.dart
@@ -45,7 +45,7 @@ class UserService {
   }
 
   Future<void> deleteAccount() async {
-    return await httpService.sendRequest(
+    await httpService.sendRequest(
       method: 'DELETE',
       url: '${AppConfig.baseUrl}/api/users',
     );

--- a/lib/Util/NotificationService.dart
+++ b/lib/Util/NotificationService.dart
@@ -1,0 +1,79 @@
+import 'dart:developer';
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:ono/Config/AppConfig.dart';
+
+import '../Service/Api/HttpService.dart';
+
+class NotificationService {
+  NotificationService._();
+  static final instance = NotificationService._();
+
+  final HttpService httpService = HttpService();
+  final FirebaseMessaging _messaging = FirebaseMessaging.instance;
+  final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
+
+  /// 앱 실행 시 한 번만 호출
+  Future<void> init() async {
+    // iOS 시뮬레이터라면 초기화 스킵
+    if (Platform.isIOS) {
+      final iosInfo = await _deviceInfo.iosInfo;
+      if (!iosInfo.isPhysicalDevice) {
+        log('▶️ iOS Simulator detected – skipping FCM init');
+        return;
+      }
+    }
+
+    await _requestPermission();
+    _configureMessageHandlers();
+  }
+
+  Future<void> _requestPermission() async {
+    final settings = await _messaging.requestPermission(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+    log('FCM permission: ${settings.authorizationStatus}');
+  }
+
+  void _configureMessageHandlers() {
+    // 포그라운드 메시지
+    FirebaseMessaging.onMessage.listen((msg) {
+      log('🛎 Foreground message: ${msg.notification?.title}');
+      // TODO: 스낵바나 다이얼로그로 표시
+    });
+
+    // 백그라운드/종료 상태에서 알림 탭 클릭
+    FirebaseMessaging.onMessageOpenedApp.listen((msg) {
+      log('🎯 Notification clicked, data: ${msg.data}');
+      // TODO: Navigator.pushNamed(...) 등으로 화면 이동
+    });
+
+    // 앱 종료/백그라운드에서도 메시지를 처리
+    FirebaseMessaging.onBackgroundMessage(_firebaseBackgroundHandler);
+  }
+
+  Future<void> sendTokenToServer() async {
+    final token = await _messaging.getToken();
+    if (token == null) return;
+
+    log('FCM token sending start');
+    await httpService.sendRequest(
+      method: 'POST',
+      url: '${AppConfig.baseUrl}/api/fcm/token',
+      body: {
+        "token": token,
+      },
+    );
+    log('✅ FCM token sent to server');
+  }
+}
+
+/// 백그라운드/종료 상태에서 호출
+Future<void> _firebaseBackgroundHandler(RemoteMessage message) async {
+  log('🔔 Background message: ${message.notification?.title}');
+  // TODO: flutter_local_notifications로 로컬 알림 띄우기
+}

--- a/lib/Util/NotificationService.dart
+++ b/lib/Util/NotificationService.dart
@@ -31,12 +31,21 @@ class NotificationService {
   }
 
   Future<void> _requestPermission() async {
-    final settings = await _messaging.requestPermission(
+    await _messaging.setForegroundNotificationPresentationOptions(
       alert: true,
       badge: true,
       sound: true,
     );
-    log('FCM permission: ${settings.authorizationStatus}');
+
+    await _messaging.requestPermission(
+      alert: true,
+      announcement: false,
+      badge: true,
+      carPlay: false,
+      criticalAlert: false,
+      provisional: false,
+      sound: true,
+    );
   }
 
   void _configureMessageHandlers() {
@@ -57,10 +66,12 @@ class NotificationService {
   }
 
   Future<void> sendTokenToServer() async {
+    final APNSToken = await _messaging.getAPNSToken();
     final token = await _messaging.getToken();
     if (token == null) return;
 
-    log('FCM token sending start');
+    log('APNS token sending start, token: ${APNSToken}');
+    log('FCM token sending start, token: ${token}');
     await httpService.sendRequest(
       method: 'POST',
       url: '${AppConfig.baseUrl}/api/fcm/token',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:developer';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -24,7 +26,14 @@ import 'Provider/UserProvider.dart';
 import 'Screen/Folder/DirectoryScreen.dart';
 import 'Screen/PracticeNote/PracticeThumbnailScreen.dart';
 import 'Screen/User/SettingScreen.dart';
+import 'Util/NotificationService.dart';
 import 'Util/SendDiscordAlert.dart';
+
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  // 앱 종료 상태에서도 이곳이 호출됩니다
+  log('🔔 백그라운드 메시지 받음: ${message.messageId}');
+  // (선택) flutter_local_notifications 등으로 로컬 알림 표시
+}
 
 void main() async {
   runZonedGuarded<Future<void>>(() async {
@@ -35,6 +44,8 @@ void main() async {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
     );
+    await NotificationService.instance.init();
+    FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
     KakaoSdk.init(nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY']!);
 
@@ -59,7 +70,6 @@ void main() async {
       );
     };
 
-    // **여기서부터 MultiProvider 전체가 Zone 안으로 들어갑니다**
     runApp(
       MultiProvider(
         providers: [

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,9 +5,11 @@
 import FlutterMacOS
 import Foundation
 
+import device_info_plus
 import file_selector_macos
 import firebase_analytics
 import firebase_core
+import firebase_messaging
 import flutter_local_notifications
 import flutter_secure_storage_macos
 import google_sign_in_ios
@@ -23,9 +25,11 @@ import url_launcher_macos
 import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAnalyticsPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "71c01c1998c40b3af1944ad0a5f374b4e6fef7f3d2df487f3970dbeadaeb25a1"
+      sha256: "214e6f07e2a44f45972e0365c7b537eaeaddb4598db0778dd4ac64b4acd3f5b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.46"
+    version: "1.3.55"
   animated_text_kit:
     dependency: "direct main"
     description:
@@ -201,6 +201,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: "0c6396126421b590089447154c5f98a5de423b70cfb15b1578fd018843ee6f53"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: "0b04e02b30791224b31969eb1b50d723498f402971bff3630bca2ba839bd1ed2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   dio:
     dependency: transitive
     description:
@@ -245,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -317,26 +333,50 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "2438a75ad803e818ad3bd5df49137ee619c46b6fc7101f4dbc23da07305ce553"
+      sha256: "8cfe3c900512399ce8d50fcc817e5758ff8615eeb6fa5c846a4cc47bbf6353b6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.13.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: e30da58198a6d4b49d5bce4e852f985c32cb10db329ebef9473db2b9f09ce810
+      sha256: d7253d255ff10f85cfd2adaba9ac17bae878fa3ba577462451163bd9f1d1f0bf
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.4.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: f967a7138f5d2ffb1ce15950e2a382924239eaa521150a8f144af34e68b3b3e5
+      sha256: ddd72baa6f727e5b23f32d9af23d7d453d67946f380bd9c21daf474ee0f7326e
       url: "https://pub.dev"
     source: hosted
-    version: "2.18.1"
+    version: "2.23.0"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: "38111089e511f03daa2c66b4c3614c16421b7d78c84ee04331a0a65b47df4542"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.6"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: ba254769982e5f439e534eed68856181c74e2b3f417c8188afad2bb440807cc7
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.6"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: dba89137272aac39e95f71408ba25c33fb8ed903cd5fa8d1e49b5cd0d96069e0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.6"
   fixnum:
     dependency: transitive
     description:
@@ -1457,10 +1497,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "84ba388638ed7a8cb3445a320c8273136ab2631cd5f2c57888335504ddab1bc2"
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0"
+    version: "5.13.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   x509:
     dependency: transitive
     description:
@@ -1486,5 +1534,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,12 +58,14 @@ dependencies:
   url_launcher_ios: ^6.3.1
   firebase_core: ^3.5.0
   firebase_analytics: ^11.3.2
+  firebase_messaging: ^15.2.6
   image_gallery_saver_plus: ^3.0.5
   flutter_tex: ^4.0.9
   animated_text_kit: ^4.2.2
   flutter_svg: ^2.0.10+1
   flutter_local_notifications: ^18.0.0
   timezone: ^0.9.4
+  device_info_plus: ^11.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #81 

## 📝 작업 내용

- 복습 노트 푸쉬 알림 기능 설정 창 구현 완료
- 복습 노트 푸쉬 알림 생성, 수정, 삭제 기능 구현 완료
- 이미지 첨부 시 문제가 등록되지 않던 버그 개선
- 문제 등록 시 키보드가 없어지지 않던 버그 개선
- 복습 노트가 삭제되지 않던 버그 개선

### 스크린샷 (선택)

<img width="300" alt="스크린샷 2025-06-18 오후 11 48 03" src="https://github.com/user-attachments/assets/589cb6bd-8e3b-4657-951f-cff0ef153ec9" />

<br>

<img width="300" alt="스크린샷 2025-06-18 오후 11 50 03" src="https://github.com/user-attachments/assets/5641b7f1-9948-46a8-b963-7043971366d7" />

