### PR TITLE
[Fix] 에러 문구 및 로직 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ app.*.map.json
 
 .env
 BUILD_COMMANDS.md
+AGENTS.local.md
+*.orig
+*.rej
 
 # Android keystore and certificates
 **/android/**/*.jks

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ app.*.map.json
 
 .env
 BUILD_COMMANDS.md
-AGENTS.local.md
+AGENTS.md
 *.orig
 *.rej
 

--- a/lib/Constants/ErrorMessages.dart
+++ b/lib/Constants/ErrorMessages.dart
@@ -1,0 +1,22 @@
+class ErrorMessages {
+  static const String unknown = '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+  static const String network = '네트워크 연결이 원활하지 않습니다. 인터넷 상태를 확인해주세요.';
+  static const String timeout = '요청 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.';
+  static const String authRequired = '로그인이 필요합니다. 다시 로그인해주세요.';
+  static const String server = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+  static const String badRequest = '요청을 처리할 수 없습니다. 입력값을 확인해주세요.';
+  static const String parse = '데이터 처리 중 오류가 발생했습니다. 다시 시도해주세요.';
+  static const String responseParse = '서버 응답 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+  static const String requestInvalid = '요청 형식이 올바르지 않습니다.';
+  static const String requiredFieldMissing = '필수 항목이 누락되었습니다.';
+  static const String notFound = '요청한 데이터를 찾을 수 없습니다.';
+  static const String forbidden = '권한이 없습니다.';
+  static const String sessionExpired = '세션이 만료되었습니다. 다시 로그인해주세요.';
+
+  static const String tagNameEmpty = '태그 이름을 입력해주세요.';
+  static const String tagNameTooLong = '태그 이름은 30자 이하여야 합니다.';
+  static const String tagNotFound = '유효하지 않은 태그입니다.';
+  static const String tagUserUnmatched = '해당 태그에 접근할 수 없습니다.';
+  static const String tagLimitExceeded = '문제당 태그는 최대 5개까지 설정할 수 있습니다.';
+}

--- a/lib/Exception/ApiException.dart
+++ b/lib/Exception/ApiException.dart
@@ -1,3 +1,6 @@
+import '../Constants/ErrorMessages.dart';
+import '../Util/ErrorMessageMapper.dart';
+
 /// API 호출 중 발생하는 예외를 처리하기 위한 커스텀 예외 클래스들
 
 /// 기본 API 예외 클래스
@@ -22,21 +25,10 @@ class ApiException implements Exception {
 
   /// 사용자에게 표시할 메시지를 반환
   String getUserMessage() {
-    // errorCode에 따른 한국어 메시지 반환
-    switch (errorCode) {
-      case 1005:
-        return '세션이 만료되었습니다. 다시 로그인해주세요.';
-      case 1001:
-        return '요청 형식이 올바르지 않습니다.';
-      case 1002:
-        return '필수 항목이 누락되었습니다.';
-      case 1003:
-        return '요청한 데이터를 찾을 수 없습니다.';
-      case 1004:
-        return '권한이 없습니다.';
-      default:
-        return message;
-    }
+    return ErrorMessageMapper.byErrorCode(
+      errorCode: errorCode,
+      fallback: ErrorMessageMapper.sanitizeRawMessage(message),
+    );
   }
 }
 
@@ -44,36 +36,39 @@ class ApiException implements Exception {
 class NetworkException implements Exception {
   final String message;
 
-  NetworkException({this.message = '네트워크 연결에 실패했습니다. 인터넷 연결을 확인해주세요.'});
+  NetworkException({this.message = ErrorMessages.network});
 
   @override
   String toString() => 'NetworkException: $message';
 
-  String getUserMessage() => message;
+  String getUserMessage() =>
+      ErrorMessageMapper.sanitizeRawMessage(message, fallback: message);
 }
 
 /// 타임아웃 예외
 class TimeoutException implements Exception {
   final String message;
 
-  TimeoutException({this.message = '요청 시간이 초과되었습니다. 다시 시도해주세요.'});
+  TimeoutException({this.message = ErrorMessages.timeout});
 
   @override
   String toString() => 'TimeoutException: $message';
 
-  String getUserMessage() => message;
+  String getUserMessage() =>
+      ErrorMessageMapper.sanitizeRawMessage(message, fallback: message);
 }
 
 /// 인증 관련 예외
 class UnauthorizedException implements Exception {
   final String message;
 
-  UnauthorizedException({this.message = '인증에 실패했습니다. 다시 로그인해주세요.'});
+  UnauthorizedException({this.message = ErrorMessages.authRequired});
 
   @override
   String toString() => 'UnauthorizedException: $message';
 
-  String getUserMessage() => message;
+  String getUserMessage() => ErrorMessageMapper.sanitizeRawMessage(message,
+      fallback: ErrorMessages.authRequired);
 }
 
 /// 서버 내부 오류 예외
@@ -83,13 +78,14 @@ class ServerException implements Exception {
 
   ServerException({
     this.statusCode,
-    this.message = '서버에서 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+    this.message = ErrorMessages.server,
   });
 
   @override
   String toString() => 'ServerException(status: $statusCode): $message';
 
-  String getUserMessage() => message;
+  String getUserMessage() => ErrorMessageMapper.sanitizeRawMessage(message,
+      fallback: ErrorMessages.server);
 }
 
 /// 잘못된 요청 예외 (400번대 에러)
@@ -109,24 +105,13 @@ class BadRequestException implements Exception {
       'BadRequestException(status: $statusCode, errorCode: $errorCode): $message';
 
   String getUserMessage() {
-    // errorCode별로 사용자 친화적인 메시지 반환
-    // errorCode가 있으면 서버에서 전달한 message를 그대로 사용
-    // 서버가 한국어 메시지를 제공하는 경우 그대로 반환
-    if (errorCode != null) {
-      return message;
-    }
-
-    // errorCode가 없는 경우 기본 메시지
-    switch (errorCode) {
-      case 1001:
-        return '입력 형식이 올바르지 않습니다.';
-      case 1002:
-        return '필수 정보를 모두 입력해주세요.';
-      case 1003:
-        return '요청한 항목을 찾을 수 없습니다.';
-      default:
-        return message;
-    }
+    return ErrorMessageMapper.byErrorCode(
+      errorCode: errorCode,
+      fallback: ErrorMessageMapper.sanitizeRawMessage(
+        message,
+        fallback: ErrorMessages.badRequest,
+      ),
+    );
   }
 }
 
@@ -134,10 +119,11 @@ class BadRequestException implements Exception {
 class ParseException implements Exception {
   final String message;
 
-  ParseException({this.message = '데이터 처리 중 오류가 발생했습니다.'});
+  ParseException({this.message = ErrorMessages.parse});
 
   @override
   String toString() => 'ParseException: $message';
 
-  String getUserMessage() => message;
+  String getUserMessage() => ErrorMessageMapper.sanitizeRawMessage(message,
+      fallback: ErrorMessages.parse);
 }

--- a/lib/Module/Dialog/LoadingDialog.dart
+++ b/lib/Module/Dialog/LoadingDialog.dart
@@ -51,6 +51,14 @@ class LoadingDialog {
     }
 
     final navigator = Navigator.of(context, rootNavigator: true);
+    hideFromNavigator(navigator);
+  }
+
+  static void hideFromNavigator(NavigatorState navigator) {
+    if (!_isShowing || !navigator.mounted) {
+      return;
+    }
+
     _isShowing = false;
 
     if (navigator.canPop()) {

--- a/lib/Module/Dialog/LoadingDialog.dart
+++ b/lib/Module/Dialog/LoadingDialog.dart
@@ -4,7 +4,14 @@ import 'package:flutter_svg/svg.dart';
 import '../Text/HandWriteText.dart';
 
 class LoadingDialog {
+  static bool _isShowing = false;
+
   static void show(BuildContext context, String message) {
+    if (_isShowing || !context.mounted) {
+      return;
+    }
+
+    _isShowing = true;
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -35,10 +42,19 @@ class LoadingDialog {
           ),
         );
       },
-    );
+    ).whenComplete(() => _isShowing = false);
   }
 
   static void hide(BuildContext context) {
-    Navigator.of(context, rootNavigator: true).pop();
+    if (!_isShowing || !context.mounted) {
+      return;
+    }
+
+    final navigator = Navigator.of(context, rootNavigator: true);
+    _isShowing = false;
+
+    if (navigator.canPop()) {
+      navigator.pop();
+    }
   }
 }

--- a/lib/Module/Dialog/SnackBarDialog.dart
+++ b/lib/Module/Dialog/SnackBarDialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../Text/StandardText.dart';
+import '../../Util/ErrorMessageMapper.dart';
 
 class SnackBarDialog {
   static void showSnackBar({
@@ -8,11 +9,12 @@ class SnackBarDialog {
     required String message,
     required Color backgroundColor,
   }) {
+    final safeMessage = ErrorMessageMapper.sanitizeRawMessage(message);
     if (ScaffoldMessenger.maybeOf(context) != null) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: StandardText(
-            text: message,
+            text: safeMessage,
             fontSize: 14,
             color: Colors.white,
           ),

--- a/lib/Module/Util/FolderNavigationButtons.dart
+++ b/lib/Module/Util/FolderNavigationButtons.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer';
 import 'dart:io';
 
@@ -9,6 +10,7 @@ import 'package:ono/Provider/FoldersProvider.dart';
 import 'package:ono/Provider/ProblemsProvider.dart';
 import 'package:ono/Provider/UserProvider.dart';
 import 'package:ono/Screen/ProblemDetail/ProblemDetailScreen.dart';
+import 'package:ono/Util/AppErrorReporter.dart';
 import 'package:provider/provider.dart';
 
 import '../../Exception/ApiException.dart';
@@ -41,6 +43,23 @@ class _FolderNavigationButtonsState extends State<FolderNavigationButtons> {
   final ImagePickerHandler _imagePickerHandler = ImagePickerHandler();
   XFile? selectedImage;
 
+  void _reportSolveError(
+    Object error,
+    StackTrace stackTrace, {
+    AppErrorSeverity severity = AppErrorSeverity.error,
+    bool sendToDiscord = true,
+  }) {
+    unawaited(
+      AppErrorReporter.report(
+        error,
+        stackTrace,
+        source: 'problem_solve',
+        severity: severity,
+        sendToDiscord: sendToDiscord,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeHandler>(context);
@@ -59,12 +78,9 @@ class _FolderNavigationButtonsState extends State<FolderNavigationButtons> {
       }
     }
 
-    int previousProblemId = currentIndex > 0
-        ? problemList[currentIndex - 1].problemId
-        : problemList.last.problemId;
-    int nextProblemId = currentIndex < problemList.length - 1
-        ? problemList[currentIndex + 1].problemId
-        : problemList.first.problemId;
+    if (currentIndex == -1) {
+      return const Center();
+    }
 
     return Container(
       width: double.infinity,
@@ -299,56 +315,81 @@ class _FolderNavigationButtonsState extends State<FolderNavigationButtons> {
                                         isLoading = true;
                                       });
 
+                                      final rootNavigator = Navigator.of(
+                                        context,
+                                        rootNavigator: true,
+                                      );
+                                      bool loadingHidden = false;
                                       LoadingDialog.show(context, '오답 복습 중...');
+                                      final solveImage =
+                                          File(selectedImage!.path);
 
                                       try {
                                         // 파일을 직접 서버로 전송
                                         final problemsProvider =
-                                            Provider.of<ProblemsProvider>(context,
+                                            Provider.of<ProblemsProvider>(
+                                                context,
+                                                listen: false);
+                                        final userProvider =
+                                            Provider.of<UserProvider>(context,
                                                 listen: false);
 
                                         await problemsProvider.problemService
                                             .registerProblemImageData(
                                           problemId: problemId,
-                                          problemImages: [File(selectedImage!.path)],
+                                          problemImages: [solveImage],
                                           problemImageTypes: ['SOLVE_IMAGE'],
                                         );
 
                                         // 문제 정보 갱신
-                                        await problemsProvider.fetchProblem(problemId);
+                                        await problemsProvider
+                                            .fetchProblem(problemId);
 
                                         FirebaseAnalytics.instance.logEvent(
                                           name: 'problem_solve',
                                         );
 
                                         // 오답노트 복습 시 유저 정보 갱신 (경험치 업데이트)
-                                        await Provider.of<UserProvider>(context,
-                                                listen: false)
-                                            .fetchUserInfo();
+                                        await userProvider.fetchUserInfo();
 
+                                        if (!context.mounted) return;
                                         setState(() {
                                           isSolved = true;
                                           isLoading = false;
                                         });
 
-                                        log("problemId: ${problemId} solve");
-                                        LoadingDialog.hide(context);
+                                        log("problemId: $problemId solve");
+                                        LoadingDialog.hideFromNavigator(
+                                          rootNavigator,
+                                        );
+                                        loadingHidden = true;
                                         Navigator.of(context).pop();
 
                                         SnackBarDialog.showSnackBar(
                                           context: context,
                                           message: '복습이 완료되었습니다!',
-                                          backgroundColor: themeProvider.primaryColor,
+                                          backgroundColor:
+                                              themeProvider.primaryColor,
                                         );
 
                                         widget.onRefresh();
-                                      } on BadRequestException catch (e) {
+                                      } on BadRequestException catch (e, stackTrace) {
+                                        _reportSolveError(
+                                          e,
+                                          stackTrace,
+                                          severity: AppErrorSeverity.warning,
+                                          sendToDiscord: false,
+                                        );
+                                        if (!context.mounted) return;
                                         // 서버 에러 (예: 이미 오늘 복습 완료)
                                         setState(() {
                                           isLoading = false;
                                         });
 
-                                        LoadingDialog.hide(context);
+                                        LoadingDialog.hideFromNavigator(
+                                          rootNavigator,
+                                        );
+                                        loadingHidden = true;
                                         Navigator.of(context).pop();
 
                                         SnackBarDialog.showSnackBar(
@@ -356,45 +397,76 @@ class _FolderNavigationButtonsState extends State<FolderNavigationButtons> {
                                           message: e.getUserMessage(),
                                           backgroundColor: Colors.red,
                                         );
-                                      } on NetworkException catch (e) {
+                                      } on NetworkException catch (e, stackTrace) {
+                                        _reportSolveError(
+                                          e,
+                                          stackTrace,
+                                          severity: AppErrorSeverity.warning,
+                                          sendToDiscord: false,
+                                        );
+                                        if (!context.mounted) return;
                                         // 네트워크 에러
                                         setState(() {
                                           isLoading = false;
                                         });
 
-                                        LoadingDialog.hide(context);
+                                        LoadingDialog.hideFromNavigator(
+                                          rootNavigator,
+                                        );
+                                        loadingHidden = true;
 
                                         SnackBarDialog.showSnackBar(
                                           context: context,
                                           message: e.getUserMessage(),
                                           backgroundColor: Colors.orange,
                                         );
-                                      } on TimeoutException catch (e) {
+                                      } on TimeoutException catch (e, stackTrace) {
+                                        _reportSolveError(
+                                          e,
+                                          stackTrace,
+                                          severity: AppErrorSeverity.warning,
+                                          sendToDiscord: false,
+                                        );
+                                        if (!context.mounted) return;
                                         // 타임아웃 에러
                                         setState(() {
                                           isLoading = false;
                                         });
 
-                                        LoadingDialog.hide(context);
+                                        LoadingDialog.hideFromNavigator(
+                                          rootNavigator,
+                                        );
+                                        loadingHidden = true;
 
                                         SnackBarDialog.showSnackBar(
                                           context: context,
                                           message: e.getUserMessage(),
                                           backgroundColor: Colors.orange,
                                         );
-                                      } catch (e) {
+                                      } catch (e, stackTrace) {
+                                        _reportSolveError(e, stackTrace);
+                                        if (!context.mounted) return;
                                         // 기타 에러
                                         setState(() {
                                           isLoading = false;
                                         });
 
-                                        LoadingDialog.hide(context);
+                                        LoadingDialog.hideFromNavigator(
+                                          rootNavigator,
+                                        );
+                                        loadingHidden = true;
 
                                         SnackBarDialog.showSnackBar(
                                           context: context,
                                           message: '알 수 없는 오류가 발생했습니다.',
                                           backgroundColor: Colors.red,
                                         );
+                                      } finally {
+                                        if (!loadingHidden) {
+                                          LoadingDialog.hideFromNavigator(
+                                            rootNavigator,
+                                          );
+                                        }
                                       }
                                     }
                                   },

--- a/lib/Provider/FoldersProvider.dart
+++ b/lib/Provider/FoldersProvider.dart
@@ -7,6 +7,7 @@ import 'package:ono/Model/Folder/FolderThumbnailModel.dart';
 import 'package:ono/Provider/ProblemsProvider.dart';
 import 'package:ono/Service/Api/FileUpload/FileUploadService.dart';
 import 'package:ono/Service/Api/Folder/FolderService.dart';
+import 'package:ono/Util/AppErrorReporter.dart';
 
 import '../Model/Folder/FolderModel.dart';
 import '../Model/Problem/ProblemModel.dart';
@@ -257,6 +258,13 @@ class FoldersProvider with ChangeNotifier {
     } catch (e, stackTrace) {
       log('Error loading subfolders: $e');
       log(stackTrace.toString());
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'folders_load_subfolders',
+        severity: AppErrorSeverity.error,
+      );
+      rethrow;
     } finally {
       state.isLoadingSubfolders = false;
       notifyListeners();
@@ -289,6 +297,13 @@ class FoldersProvider with ChangeNotifier {
     } catch (e, stackTrace) {
       log('Error loading problems: $e');
       log(stackTrace.toString());
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'folders_load_problems',
+        severity: AppErrorSeverity.error,
+      );
+      rethrow;
     } finally {
       state.isLoadingProblems = false;
       notifyListeners();

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -11,6 +11,7 @@ import '../Model/PracticeNote/PracticeNoteThumbnailModel.dart';
 import '../Model/Problem/ProblemModel.dart';
 import '../Service/Api/HttpService.dart';
 import '../Service/Api/PracticeNote/PracticeNoteService.dart';
+import '../Util/AppErrorReporter.dart';
 import 'TokenProvider.dart';
 
 class ProblemPracticeProvider with ChangeNotifier {
@@ -119,6 +120,12 @@ class ProblemPracticeProvider with ChangeNotifier {
       } catch (e, stackTrace) {
         log('Error loading problem $problemId: $e');
         log('Stack trace: $stackTrace');
+        await AppErrorReporter.report(
+          e,
+          stackTrace,
+          source: 'practice_note_problem_partial_load',
+          severity: AppErrorSeverity.warning,
+        );
         // 문제 로드 실패해도 계속 진행
       }
     }
@@ -303,6 +310,12 @@ class ProblemPracticeProvider with ChangeNotifier {
     } catch (e, stackTrace) {
       log('Error updating single practice thumbnail: $e');
       log('Stack trace: $stackTrace');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'practice_thumbnail_update',
+        severity: AppErrorSeverity.warning,
+      );
     }
   }
 

--- a/lib/Provider/ProblemsProvider.dart
+++ b/lib/Provider/ProblemsProvider.dart
@@ -12,6 +12,7 @@ import 'package:ono/Service/Api/Problem/ProblemService.dart';
 import '../Model/Problem/ProblemRegisterModel.dart';
 import '../Module/Util/ReviewHandler.dart';
 import '../Service/Api/FileUpload/FileUploadService.dart';
+import '../Util/AppErrorReporter.dart';
 
 class ProblemsProvider with ChangeNotifier {
   // SplayTreeMap: O(log n) 삽입, O(log n) 조회, 자동 정렬
@@ -93,6 +94,12 @@ class ProblemsProvider with ChangeNotifier {
       log('문제 분석 결과 조회 실패 - Problem ID: $problemId');
       log('에러: $e');
       log('스택트레이스: $stackTrace');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'problem_analysis_fetch',
+        severity: AppErrorSeverity.warning,
+      );
     }
   }
 

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -15,7 +15,6 @@ import 'package:ono/Service/Api/User/UserService.dart';
 import 'package:ono/Service/SocialLogin/KakaoAuthService.dart';
 import 'package:ono/Util/AppErrorReporter.dart';
 import 'package:ono/Util/NotificationService.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../Exception/ApiException.dart';
 import '../Module/Text/StandardText.dart';
@@ -92,7 +91,7 @@ class UserProvider with ChangeNotifier {
         );
         return;
       }
-      await _handleGeneralError(context, error, stackTrace);
+      await _handleGeneralError(context, error, stackTrace, source: 'login');
     }
   }
 
@@ -127,7 +126,12 @@ class UserProvider with ChangeNotifier {
         );
         return;
       }
-      await _handleGeneralError(context, error, stackTrace);
+      await _handleGeneralError(
+        context,
+        error,
+        stackTrace,
+        source: 'guest_login',
+      );
     }
   }
 
@@ -147,13 +151,14 @@ class UserProvider with ChangeNotifier {
   Future<void> _handleGeneralError(
     BuildContext context,
     Object error,
-    StackTrace stackTrace,
-  ) async {
+    StackTrace stackTrace, {
+    String source = 'login',
+  }) async {
     await resetUserInfo();
     await AppErrorReporter.report(
       error,
       stackTrace,
-      source: 'login',
+      source: source,
       severity: AppErrorSeverity.error,
     );
 
@@ -193,6 +198,7 @@ class UserProvider with ChangeNotifier {
     }
     return '로그인 과정에서 오류가 발생했습니다. 다시 시도해주세요.';
   }
+
   void changeIsFirstLogin() {
     _isFirstLogin = false;
     notifyListeners();
@@ -204,7 +210,6 @@ class UserProvider with ChangeNotifier {
   }
 
   Future<bool> saveUserToken({dynamic response}) async {
-    log('Server response: $response');
     log('Response type: ${response.runtimeType}');
 
     if (response == null) {
@@ -216,9 +221,6 @@ class UserProvider with ChangeNotifier {
 
     String? accessToken = response['accessToken'] as String?;
     String? refreshToken = response['refreshToken'] as String?;
-
-    log('accessToken: $accessToken');
-    log('refreshToken: $refreshToken');
 
     if (accessToken == null || refreshToken == null) {
       _loginStatus = LoginStatus.logout;
@@ -286,16 +288,31 @@ class UserProvider with ChangeNotifier {
       } catch (error, stackTrace) {
         // 데이터 로딩 실패만으로 세션을 끊지 않음
         log('자동 로그인 후 데이터 로딩 실패: $error');
-        await Sentry.captureException(error, stackTrace: stackTrace);
+        await AppErrorReporter.report(
+          error,
+          stackTrace,
+          source: 'auto_login_fetch_data',
+          severity: AppErrorSeverity.warning,
+        );
       }
     } on UnauthorizedException catch (error, stackTrace) {
       log('자동 로그인 실패(인증 만료): $error');
-      await Sentry.captureException(error, stackTrace: stackTrace);
+      await AppErrorReporter.report(
+        error,
+        stackTrace,
+        source: 'auto_login_unauthorized',
+        severity: AppErrorSeverity.warning,
+      );
       await _handleAuthFailure();
     } catch (error, stackTrace) {
       // 일시적인 네트워크 오류 등은 로그인 상태 유지
       log('자동 로그인 일시 실패: $error');
-      await Sentry.captureException(error, stackTrace: stackTrace);
+      await AppErrorReporter.report(
+        error,
+        stackTrace,
+        source: 'auto_login_refresh',
+        severity: AppErrorSeverity.warning,
+      );
       _isFirstLogin = false;
       _loginStatus = LoginStatus.login;
     } finally {
@@ -311,12 +328,22 @@ class UserProvider with ChangeNotifier {
       await tokenProvider.refreshAccessTokenIfNeeded();
     } on UnauthorizedException catch (error, stackTrace) {
       log('앱 복귀 중 인증 만료: $error');
-      await Sentry.captureException(error, stackTrace: stackTrace);
+      await AppErrorReporter.report(
+        error,
+        stackTrace,
+        source: 'session_resume_unauthorized',
+        severity: AppErrorSeverity.warning,
+      );
       await _handleAuthFailure();
     } catch (error, stackTrace) {
       // 복귀 순간 네트워크 이슈로는 세션을 끊지 않음
       log('앱 복귀 중 세션 갱신 일시 실패: $error');
-      await Sentry.captureException(error, stackTrace: stackTrace);
+      await AppErrorReporter.report(
+        error,
+        stackTrace,
+        source: 'session_resume_refresh',
+        severity: AppErrorSeverity.warning,
+      );
     }
   }
 

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -2,9 +2,7 @@ import 'dart:core';
 import 'dart:developer';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:ono/Model/Common/LoginStatus.dart';
 import 'package:ono/Model/User/UserInfoModel.dart';
@@ -15,6 +13,7 @@ import 'package:ono/Provider/PracticeNoteProvider.dart';
 import 'package:ono/Service/Api/Problem/ProblemService.dart';
 import 'package:ono/Service/Api/User/UserService.dart';
 import 'package:ono/Service/SocialLogin/KakaoAuthService.dart';
+import 'package:ono/Util/AppErrorReporter.dart';
 import 'package:ono/Util/NotificationService.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -23,7 +22,6 @@ import '../Module/Text/StandardText.dart';
 import '../Service/Api/HttpService.dart';
 import '../Service/SocialLogin/AppleAuthService.dart';
 import '../Service/SocialLogin/GoogleAuthService.dart';
-import '../Util/SendDiscordAlert.dart';
 import 'ProblemsProvider.dart';
 import 'TokenProvider.dart';
 
@@ -62,7 +60,7 @@ class UserProvider with ChangeNotifier {
       final response = await userService.signInWithMember(userRegisterModel);
       log('[signInWithMember] response received');
 
-      saveUserLoginInfo(userRegisterModel?.platform);
+      await saveUserLoginInfo(userRegisterModel?.platform);
       bool isRegister = await saveUserToken(response: response);
       log('[signInWithMember] isRegister: $isRegister');
 
@@ -72,11 +70,12 @@ class UserProvider with ChangeNotifier {
       await fetchAllData();
       log('[signInWithMember] all data fetched');
 
-      LoadingDialog.hide(context);
-
       _loginStatus = LoginStatus.login;
       notifyListeners();
       log('[signInWithMember] login status set to login');
+
+      if (!context.mounted) return;
+      LoadingDialog.hide(context);
 
       if (!isRegister) {
         log('register failed!, response: ${response.toString()}');
@@ -84,7 +83,16 @@ class UserProvider with ChangeNotifier {
       }
     } catch (error, stackTrace) {
       log('[signInWithMember] error occurred: $error');
-      _handleGeneralError(context, error, stackTrace);
+      if (!context.mounted) {
+        await AppErrorReporter.report(
+          error,
+          stackTrace,
+          source: 'login',
+          severity: AppErrorSeverity.error,
+        );
+        return;
+      }
+      await _handleGeneralError(context, error, stackTrace);
     }
   }
 
@@ -93,21 +101,33 @@ class UserProvider with ChangeNotifier {
       LoadingDialog.show(context, '로그인 중 입니다...');
       final response = await userService.signInWithGuest();
 
-      saveUserLoginInfo("GUEST");
+      await saveUserLoginInfo('GUEST');
       bool isRegister = await saveUserToken(response: response);
 
+      await NotificationService.instance.sendTokenToServer();
       await fetchAllData();
-      LoadingDialog.hide(context);
 
       _loginStatus = LoginStatus.login;
       notifyListeners();
+
+      if (!context.mounted) return;
+      LoadingDialog.hide(context);
 
       if (!isRegister) {
         log('register failed!, response: ${response.toString()}');
         throw Exception('response: ${response.toString()}');
       }
     } catch (error, stackTrace) {
-      _handleGeneralError(context, error, stackTrace);
+      if (!context.mounted) {
+        await AppErrorReporter.report(
+          error,
+          stackTrace,
+          source: 'guest_login',
+          severity: AppErrorSeverity.error,
+        );
+        return;
+      }
+      await _handleGeneralError(context, error, stackTrace);
     }
   }
 
@@ -124,11 +144,22 @@ class UserProvider with ChangeNotifier {
   }
 
   // 일반 오류 처리 메서드
-  void _handleGeneralError(
-      BuildContext context, Object error, StackTrace stackTrace) async {
+  Future<void> _handleGeneralError(
+    BuildContext context,
+    Object error,
+    StackTrace stackTrace,
+  ) async {
     await resetUserInfo();
-    await Sentry.captureException(error, stackTrace: stackTrace);
-    await _sendLoginFailureAlert(error, stackTrace);
+    await AppErrorReporter.report(
+      error,
+      stackTrace,
+      source: 'login',
+      severity: AppErrorSeverity.error,
+    );
+
+    if (!context.mounted) {
+      return;
+    }
 
     LoadingDialog.hide(context);
 
@@ -162,24 +193,6 @@ class UserProvider with ChangeNotifier {
     }
     return '로그인 과정에서 오류가 발생했습니다. 다시 시도해주세요.';
   }
-
-  Future<void> _sendLoginFailureAlert(
-      Object error, StackTrace stackTrace) async {
-    final prodUrl = dotenv.env['DISCORD_WEBHOOK_PROD_URL'];
-    final localUrl = dotenv.env['DISCORD_WEBHOOK_LOCAL_URL'];
-    final webhookUrl = kReleaseMode ? prodUrl : localUrl;
-    if (webhookUrl == null || webhookUrl.isEmpty) {
-      log('Discord webhook URL is not configured.');
-      return;
-    }
-
-    await sendDiscordAlert(
-      message: '[LoginError] ${error.toString()}',
-      stack: stackTrace,
-      webhookUrl: webhookUrl,
-    );
-  }
-
   void changeIsFirstLogin() {
     _isFirstLogin = false;
     notifyListeners();
@@ -310,13 +323,13 @@ class UserProvider with ChangeNotifier {
   Future<void> signOut() async {
     String? loginMethod = await storage.read(key: 'loginMethod');
     if (loginMethod == 'google') {
-      googleAuthService.logoutGoogleSignIn();
+      await googleAuthService.logoutGoogleSignIn();
     } else if (loginMethod == 'apple') {
       // apple 은 별도의 로그아웃 로직이 없습니다.
     } else if (loginMethod == 'kakao') {
       await kakaoAuthService.logoutKakaoSignIn();
     } else if (loginMethod == 'guest') {
-      deleteAccount();
+      await deleteAccount();
     }
 
     await userService.logoutAccount();
@@ -338,7 +351,7 @@ class UserProvider with ChangeNotifier {
     } else if (loginMethod == 'guest') {
     } else {}
 
-    userService.deleteAccount();
+    await userService.deleteAccount();
     await resetUserInfo();
 
     await FirebaseAnalytics.instance.logEvent(

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -24,6 +24,7 @@ import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Module/Util/FolderPickerDialog.dart';
 import '../../Provider/UserProvider.dart';
+import '../../Util/AppErrorReporter.dart';
 import '../ProblemDetail/ProblemDetailScreen.dart';
 import '../ProblemRegister/ProblemRegisterScreen.dart';
 import '../ProblemSearch/TagProblemSearchScreen.dart';
@@ -276,6 +277,19 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     } catch (e, stackTrace) {
       log('Error loading subfolders locally: $e');
       log(stackTrace.toString());
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'directory_load_subfolders',
+        severity: AppErrorSeverity.error,
+      );
+      if (mounted) {
+        SnackBarDialog.showSnackBar(
+          context: context,
+          message: '폴더 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+          backgroundColor: Colors.redAccent,
+        );
+      }
     } finally {
       if (mounted) {
         setState(() {
@@ -407,6 +421,19 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     } catch (e, stackTrace) {
       log('Error loading problems locally: $e');
       log(stackTrace.toString());
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'directory_load_problems',
+        severity: AppErrorSeverity.error,
+      );
+      if (mounted) {
+        SnackBarDialog.showSnackBar(
+          context: context,
+          message: '문제 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+          backgroundColor: Colors.redAccent,
+        );
+      }
     } finally {
       if (mounted) {
         setState(() {

--- a/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
@@ -20,6 +20,8 @@ import '../../Module/Theme/NoteIconHandler.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/FoldersProvider.dart';
 import '../../Provider/ProblemsProvider.dart';
+import '../../Util/AppErrorReporter.dart';
+import '../../Util/AppSnackBar.dart';
 
 enum _PracticeSearchMode { folder, tag, title }
 
@@ -157,12 +159,19 @@ class _PracticeProblemSelectionScreenState
           _loadInitialProblems(allFolders[0].folderId);
         }
       });
-    } catch (e) {
-      print('Error loading folders: $e');
+    } catch (e, stackTrace) {
+      await _reportAndShowLoadError(
+        e,
+        stackTrace,
+        source: 'practice_selection_load_folders',
+        message: '폴더 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
     } finally {
-      setState(() {
-        _isLoadingFolders = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoadingFolders = false;
+        });
+      }
     }
   }
 
@@ -186,12 +195,19 @@ class _PracticeProblemSelectionScreenState
         _folderCursor = response.nextCursor;
         _folderHasNext = response.hasNext;
       });
-    } catch (e) {
-      print('Error loading more folders: $e');
+    } catch (e, stackTrace) {
+      await _reportAndShowLoadError(
+        e,
+        stackTrace,
+        source: 'practice_selection_load_more_folders',
+        message: '폴더 목록을 더 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
     } finally {
-      setState(() {
-        _isLoadingFolders = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoadingFolders = false;
+        });
+      }
     }
   }
 
@@ -207,6 +223,13 @@ class _PracticeProblemSelectionScreenState
           _selectedTagId = _tags.first.tagId;
         }
       });
+    } catch (e, stackTrace) {
+      await _reportAndShowLoadError(
+        e,
+        stackTrace,
+        source: 'practice_selection_load_tags',
+        message: '태그 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
     } finally {
       if (mounted) {
         setState(() => _isLoadingTags = false);
@@ -267,12 +290,19 @@ class _PracticeProblemSelectionScreenState
         _problemCursor = response.nextCursor;
         _problemHasNext = response.hasNext;
       });
-    } catch (e) {
-      print('Error loading problems: $e');
+    } catch (e, stackTrace) {
+      await _reportAndShowLoadError(
+        e,
+        stackTrace,
+        source: 'practice_selection_load_folder_problems',
+        message: '문제 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
     } finally {
-      setState(() {
-        _isLoadingProblems = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoadingProblems = false;
+        });
+      }
     }
   }
 
@@ -312,8 +342,13 @@ class _PracticeProblemSelectionScreenState
         _problemCursor = response.nextCursor;
         _problemHasNext = response.hasNext;
       });
-    } catch (e) {
-      print('Error loading tag problems: $e');
+    } catch (e, stackTrace) {
+      await _reportAndShowLoadError(
+        e,
+        stackTrace,
+        source: 'practice_selection_load_tag_problems',
+        message: '태그 문제를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
     } finally {
       if (mounted) {
         setState(() {
@@ -372,8 +407,13 @@ class _PracticeProblemSelectionScreenState
         _problemCursor = response.nextCursor;
         _problemHasNext = response.hasNext;
       });
-    } catch (e) {
-      print('Error loading title problems: $e');
+    } catch (e, stackTrace) {
+      await _reportAndShowLoadError(
+        e,
+        stackTrace,
+        source: 'practice_selection_search_title_problems',
+        message: '검색 결과를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+      );
     } finally {
       if (mounted) {
         setState(() {
@@ -405,12 +445,19 @@ class _PracticeProblemSelectionScreenState
           _problemCursor = response.nextCursor;
           _problemHasNext = response.hasNext;
         });
-      } catch (e) {
-        print('Error loading more folder problems: $e');
+      } catch (e, stackTrace) {
+        await _reportAndShowLoadError(
+          e,
+          stackTrace,
+          source: 'practice_selection_load_more_folder_problems',
+          message: '문제 목록을 더 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+        );
       } finally {
-        setState(() {
-          _isLoadingProblems = false;
-        });
+        if (mounted) {
+          setState(() {
+            _isLoadingProblems = false;
+          });
+        }
       }
       return;
     }
@@ -422,6 +469,24 @@ class _PracticeProblemSelectionScreenState
     }
 
     await _searchTitleProblems(_titleQuery, isInitial: false);
+  }
+
+  Future<void> _reportAndShowLoadError(
+    Object error,
+    StackTrace stackTrace, {
+    required String source,
+    required String message,
+  }) async {
+    await AppErrorReporter.report(
+      error,
+      stackTrace,
+      source: source,
+      severity: AppErrorSeverity.error,
+    );
+
+    if (mounted) {
+      AppSnackBar.showError(message);
+    }
   }
 
   @override

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -14,6 +14,7 @@ import '../../Module/Dialog/SnackBarDialog.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/PracticeNoteProvider.dart';
+import '../../Util/AppErrorReporter.dart';
 
 class PracticeTitleWriteScreen extends StatefulWidget {
   final PracticeNoteRegisterModel? practiceRegisterModel;
@@ -113,6 +114,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           await problemPracticeProvider
               .updatePractice(widget.practiceNoteUpdateModel!);
 
+          if (!context.mounted) return;
           _showSnackBar(context, themeProvider, '복습 노트가 수정되었습니다.',
               themeProvider.primaryColor);
 
@@ -140,16 +142,32 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           await problemPracticeProvider
               .registerPractice(widget.practiceRegisterModel!);
 
+          if (!context.mounted) return;
           _showSnackBar(context, themeProvider, '복습 노트가 생성되었습니다.',
               themeProvider.primaryColor);
 
           Navigator.pop(context);
           Navigator.pop(context);
         }
-      } catch (error) {
+      } catch (error, stackTrace) {
         log(error.toString());
-        _showSnackBar(context, themeProvider, '복습 노트 생성에 실패했습니다.', Colors.red);
-        throw Exception(error);
+        final isUpdate = widget.practiceNoteUpdateModel != null;
+        await AppErrorReporter.report(
+          error,
+          stackTrace,
+          source: isUpdate ? 'practice_note_update' : 'practice_note_create',
+          severity: AppErrorSeverity.error,
+        );
+        if (context.mounted) {
+          _showSnackBar(
+            context,
+            themeProvider,
+            isUpdate
+                ? '복습 노트 수정에 실패했습니다. 잠시 후 다시 시도해주세요.'
+                : '복습 노트 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
+            Colors.red,
+          );
+        }
       }
     }
   }

--- a/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
@@ -5,6 +5,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:ono/Provider/PracticeNoteProvider.dart';
 import 'package:ono/Screen/ProblemRegister/ProblemRegisterScreen.dart';
+import 'package:ono/Util/AppErrorReporter.dart';
 import 'package:provider/provider.dart';
 
 import '../../Model/Problem/ProblemAnalysisStatus.dart';
@@ -31,6 +32,8 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
   Future<ProblemModel?>? _problemModelFuture;
   Timer? _analysisPollingTimer;
   int _pollingCount = 0;
+  int _analysisPollingFailureCount = 0;
+  static const int _maxAnalysisPollingFailures = 3;
   bool _isExpansionTileExpanded = false; // ExpansionTile 상태 관리
   bool _isProblemDeleted = false; // 문제 삭제 여부 플래그
 
@@ -62,6 +65,7 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
     // 기존 타이머가 있으면 취소
     _stopAnalysisPolling();
     _pollingCount = 0;
+    _analysisPollingFailureCount = 0;
 
     log('🔄 Started analysis polling for problem $problemId');
 
@@ -105,6 +109,7 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
 
         // 서버에서 최신 분석 상태 조회
         await problemsProvider.fetchProblemAnalysis(problemId);
+        _analysisPollingFailureCount = 0;
 
         // 현재 문제 상태 확인
         final problem = await problemsProvider.getProblem(problemId);
@@ -144,9 +149,23 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
 
         // 여전히 진행 중이면 다음 폴링 예약
         _pollAnalysisStatus(problemId);
-      } catch (e) {
+      } catch (e, stackTrace) {
+        _analysisPollingFailureCount++;
         log('⚠️ Error during analysis polling: $e');
-        // 에러 발생해도 계속 시도
+        await AppErrorReporter.report(
+          e,
+          stackTrace,
+          source: 'problem_analysis_polling',
+          severity: AppErrorSeverity.warning,
+          sendToDiscord:
+              _analysisPollingFailureCount >= _maxAnalysisPollingFailures,
+        );
+        if (_analysisPollingFailureCount >= _maxAnalysisPollingFailures) {
+          log('⏱️ Analysis polling stopped after repeated failures');
+          _stopAnalysisPolling();
+          return;
+        }
+
         _pollAnalysisStatus(problemId);
       }
     });
@@ -156,6 +175,7 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
     _analysisPollingTimer?.cancel();
     _analysisPollingTimer = null;
     _pollingCount = 0;
+    _analysisPollingFailureCount = 0;
   }
 
   @override

--- a/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
+++ b/lib/Screen/ProblemDetail/Widget/RepeatSectionV2.dart
@@ -913,7 +913,7 @@ class _ProblemSolveCard extends StatelessWidget {
       if (context.mounted) {
         SnackBarDialog.showSnackBar(
           context: context,
-          message: '복습 기록 삭제에 실패했습니다: $e',
+          message: '복습 기록 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.',
           backgroundColor: Colors.red,
         );
       }

--- a/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
@@ -22,6 +22,7 @@ import '../../Provider/UserProvider.dart';
 import '../../Service/Api/FileUpload/FileUploadService.dart';
 import '../../Service/Api/Problem/ProblemService.dart';
 import '../../Service/Api/Tag/TagService.dart';
+import '../../Util/AppErrorReporter.dart';
 import 'TagSelectionScreen.dart';
 import 'Widget/DatePickerWidget.dart';
 import 'Widget/ImageGridWidget.dart';
@@ -815,6 +816,7 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
 
     if (!widget.isEditMode) {
       await _waitForPendingUploads();
+      if (!mounted) return;
       if (_existingProblemImageUrls.isEmpty) {
         _showProblemImageRequiredDialog(context);
         return;
@@ -825,6 +827,7 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
     LoadingDialog.show(
         context, widget.isEditMode ? '오답노트 수정 중...' : '오답노트 작성 중...');
     bool shouldPop = false;
+    bool loadingHidden = false;
     try {
       if (widget.isEditMode) {
         await _updateProblem();
@@ -836,9 +839,30 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
     } catch (e, stackTrace) {
       log('오답노트 ${widget.isEditMode ? "수정" : "등록"} 실패: $e');
       log(stackTrace.toString());
-      throw Exception(e);
+      if (mounted) {
+        LoadingDialog.hide(context);
+        loadingHidden = true;
+        SnackBarDialog.showSnackBar(
+          context: context,
+          message: widget.isEditMode
+              ? '오답노트 수정에 실패했습니다. 잠시 후 다시 시도해주세요.'
+              : '오답노트 등록에 실패했습니다. 잠시 후 다시 시도해주세요.',
+          backgroundColor: Colors.red,
+        );
+      }
+      unawaited(
+        AppErrorReporter.report(
+          e,
+          stackTrace,
+          source: widget.isEditMode ? 'problem_update' : 'problem_register',
+          severity: AppErrorSeverity.error,
+        ),
+      );
+      return;
     } finally {
-      LoadingDialog.hide(context);
+      if (mounted && !loadingHidden) {
+        LoadingDialog.hide(context);
+      }
     }
 
     if (!mounted) return;
@@ -1014,6 +1038,9 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
 
     final problemsProvider =
         Provider.of<ProblemsProvider>(context, listen: false);
+    final userProvider = Provider.of<UserProvider>(context, listen: false);
+    final foldersProvider =
+        Provider.of<FoldersProvider>(context, listen: false);
     final problemService = ProblemService();
     final registeredProblemId = await problemService.registerProblemV2(
       problemId: null,
@@ -1032,14 +1059,15 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
     // Provider를 통해 문제 조회 및 상태 업데이트
     await problemsProvider.fetchProblem(registeredProblemId);
     await problemsProvider.updateProblemCount(1);
+    if (!context.mounted) return;
+    // requestReview may show a fallback dialog, so keep the mounted guard above.
+    // ignore: use_build_context_synchronously
     await problemsProvider.requestReview(context);
 
     // 2. 유저 정보 갱신 (경험치 업데이트)
-    await Provider.of<UserProvider>(context, listen: false).fetchUserInfo();
+    await userProvider.fetchUserInfo();
 
     // 3. 폴더 갱신 (화면 전환 전에 먼저 캐시 삭제 및 타임스탬프 업데이트)
-    final foldersProvider =
-        Provider.of<FoldersProvider>(context, listen: false);
     if (_selectedFolderId != null) {
       await foldersProvider.refreshFolder(_selectedFolderId!);
     } else {

--- a/lib/Screen/ProblemRegister/TemplateSelectionScreen.dart
+++ b/lib/Screen/ProblemRegister/TemplateSelectionScreen.dart
@@ -344,6 +344,10 @@ class _TemplateSelectionScreenState extends State<TemplateSelectionScreen> {
           LoadingDialog.show(context, '템플릿 불러오는 중...');
           final result = null;
 
+          if (!context.mounted) {
+            return;
+          }
+
           if (result != null) {
             final problemModel = ProblemModel(
               problemId: result['problemId'],
@@ -361,6 +365,7 @@ class _TemplateSelectionScreenState extends State<TemplateSelectionScreen> {
               },
             );
           } else {
+            LoadingDialog.hide(context);
             SnackBarDialog.showSnackBar(
               context: context,
               message: "문제 이미지 업로드에 실패했습니다. 다시 시도해주세요.",

--- a/lib/Screen/ProblemShare/AnswerShareScreen.dart
+++ b/lib/Screen/ProblemShare/AnswerShareScreen.dart
@@ -16,6 +16,8 @@ import '../../Module/Text/StandardText.dart';
 import '../../Module/Text/UnderlinedText.dart';
 import '../../Module/Theme/GridPainter.dart';
 import '../../Module/Theme/ThemeHandler.dart';
+import '../../Util/AppErrorReporter.dart';
+import '../../Util/AppSnackBar.dart';
 
 class AnswerShareScreen extends StatefulWidget {
   final ProblemModel problem;
@@ -256,12 +258,13 @@ class _AnswerShareScreenState extends State<AnswerShareScreen> {
 
       await Future.delayed(const Duration(milliseconds: 30));
 
+      if (!mounted) return;
+      final pixelRatio = MediaQuery.of(context).devicePixelRatio;
       RenderRepaintBoundary boundary = widget._globalKey.currentContext!
           .findRenderObject() as RenderRepaintBoundary;
 
       // 이미지를 캡처합니다.
-      ui.Image image = await boundary.toImage(
-          pixelRatio: MediaQuery.of(context).devicePixelRatio);
+      ui.Image image = await boundary.toImage(pixelRatio: pixelRatio);
 
       // 불투명한 배경을 가진 새로운 캔버스를 생성합니다.
       final paint = Paint();
@@ -288,12 +291,13 @@ class _AnswerShareScreenState extends State<AnswerShareScreen> {
 
       final XFile xFile = XFile(file.path);
 
+      if (!mounted) return;
       final RenderBox box = context.findRenderObject() as RenderBox;
       final rect = box.localToGlobal(Offset.zero) & box.size;
       final size = MediaQuery.of(context).size;
 
       if (rect.size.width > 0 && rect.size.height > 0) {
-        Share.shareXFiles(
+        await Share.shareXFiles(
           [xFile],
           text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home',
           sharePositionOrigin: Rect.fromPoints(
@@ -303,17 +307,28 @@ class _AnswerShareScreenState extends State<AnswerShareScreen> {
         );
       } else {
         log('Invalid box size, defaulting to basic share...');
-        Share.shareXFiles(
+        await Share.shareXFiles(
           [xFile],
           text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home',
         );
       }
 
       // 공유 후 화면을 닫습니다.
-      Navigator.pop(context);
+      if (mounted) {
+        Navigator.pop(context);
+      }
     } catch (e, stackTrace) {
       log('이미지 공유 실패: $e');
       log('스택 트레이스: $stackTrace');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'answer_share_image',
+        severity: AppErrorSeverity.error,
+      );
+      if (mounted) {
+        AppSnackBar.showError('이미지를 공유하지 못했습니다. 잠시 후 다시 시도해주세요.');
+      }
     }
   }
 }

--- a/lib/Screen/ProblemShare/ProblemShareScreen.dart
+++ b/lib/Screen/ProblemShare/ProblemShareScreen.dart
@@ -17,6 +17,8 @@ import '../../Module/Text/StandardText.dart';
 import '../../Module/Text/UnderlinedText.dart';
 import '../../Module/Theme/GridPainter.dart';
 import '../../Module/Theme/ThemeHandler.dart';
+import '../../Util/AppErrorReporter.dart';
+import '../../Util/AppSnackBar.dart';
 
 class ProblemShareScreen extends StatefulWidget {
   final ProblemModel problem;
@@ -265,12 +267,13 @@ class _ProblemShareScreenState extends State<ProblemShareScreen> {
 
       await Future.delayed(const Duration(milliseconds: 30));
 
+      if (!mounted) return;
+      final pixelRatio = MediaQuery.of(context).devicePixelRatio;
       RenderRepaintBoundary boundary = widget._globalKey.currentContext!
           .findRenderObject() as RenderRepaintBoundary;
 
       // 이미지를 캡처합니다.
-      ui.Image image = await boundary.toImage(
-          pixelRatio: MediaQuery.of(context).devicePixelRatio);
+      ui.Image image = await boundary.toImage(pixelRatio: pixelRatio);
 
       // 불투명한 배경을 가진 새로운 캔버스를 생성합니다.
       final paint = Paint();
@@ -297,12 +300,13 @@ class _ProblemShareScreenState extends State<ProblemShareScreen> {
 
       final XFile xFile = XFile(file.path);
 
+      if (!mounted) return;
       final RenderBox box = context.findRenderObject() as RenderBox;
       final rect = box.localToGlobal(Offset.zero) & box.size;
       final size = MediaQuery.of(context).size;
 
       if (rect.size.width > 0 && rect.size.height > 0) {
-        Share.shareXFiles(
+        await Share.shareXFiles(
           [xFile],
           text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home',
           sharePositionOrigin: Rect.fromPoints(
@@ -312,14 +316,25 @@ class _ProblemShareScreenState extends State<ProblemShareScreen> {
         );
       } else {
         log('Invalid box size, defaulting to basic share...');
-        Share.shareXFiles([xFile],
+        await Share.shareXFiles([xFile],
             text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home');
       }
 
-      Navigator.pop(context);
+      if (mounted) {
+        Navigator.pop(context);
+      }
     } catch (e, stackTrace) {
       log('이미지 공유 실패: $e');
       log('스택 트레이스: $stackTrace');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'problem_share_image',
+        severity: AppErrorSeverity.error,
+      );
+      if (mounted) {
+        AppSnackBar.showError('이미지를 공유하지 못했습니다. 잠시 후 다시 시도해주세요.');
+      }
     }
   }
 }

--- a/lib/Screen/ProblemSolve/ProblemSolveRegisterScreen.dart
+++ b/lib/Screen/ProblemSolve/ProblemSolveRegisterScreen.dart
@@ -186,7 +186,7 @@ class _ProblemSolveRegisterScreenState
         LoadingDialog.hide(context);
         SnackBarDialog.showSnackBar(
           context: context,
-          message: '복습 기록 저장에 실패했습니다: $e',
+          message: '복습 기록 저장에 실패했습니다. 잠시 후 다시 시도해주세요.',
           backgroundColor: Colors.red,
         );
       }

--- a/lib/Service/Api/HttpService.dart
+++ b/lib/Service/Api/HttpService.dart
@@ -6,22 +6,62 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
+import '../../Constants/ErrorMessages.dart';
 import '../../Exception/ApiException.dart';
 import '../../Provider/TokenProvider.dart';
 import '../../Util/AppSnackBar.dart';
+import '../../Util/ErrorMessageMapper.dart';
 
 class HttpService {
   final TokenProvider tokenProvider = TokenProvider();
 
   String _getErrorMessage(Object error) {
-    if (error is UnauthorizedException) return error.getUserMessage();
-    if (error is NetworkException) return error.getUserMessage();
-    if (error is TimeoutException) return error.getUserMessage();
-    if (error is ServerException) return error.getUserMessage();
-    if (error is BadRequestException) return error.getUserMessage();
-    if (error is ParseException) return error.getUserMessage();
-    if (error is ApiException) return error.getUserMessage();
-    return '알 수 없는 오류가 발생했습니다.';
+    if (error is UnauthorizedException) {
+      return ErrorMessageMapper.sanitizeRawMessage(
+        error.getUserMessage(),
+        fallback: ErrorMessages.authRequired,
+      );
+    }
+    if (error is NetworkException) {
+      return ErrorMessageMapper.sanitizeRawMessage(
+        error.getUserMessage(),
+        fallback: ErrorMessages.network,
+      );
+    }
+    if (error is TimeoutException) {
+      return ErrorMessageMapper.sanitizeRawMessage(
+        error.getUserMessage(),
+        fallback: ErrorMessages.timeout,
+      );
+    }
+    if (error is ServerException) {
+      return ErrorMessageMapper.sanitizeRawMessage(
+        error.getUserMessage(),
+        fallback: ErrorMessages.server,
+      );
+    }
+    if (error is BadRequestException) {
+      return ErrorMessageMapper.byErrorCode(
+        errorCode: error.errorCode,
+        fallback: ErrorMessageMapper.sanitizeRawMessage(
+          error.getUserMessage(),
+          fallback: ErrorMessages.badRequest,
+        ),
+      );
+    }
+    if (error is ParseException) {
+      return ErrorMessageMapper.sanitizeRawMessage(
+        error.getUserMessage(),
+        fallback: ErrorMessages.parse,
+      );
+    }
+    if (error is ApiException) {
+      return ErrorMessageMapper.byErrorCode(
+        errorCode: error.errorCode,
+        fallback: ErrorMessageMapper.sanitizeRawMessage(error.getUserMessage()),
+      );
+    }
+    return ErrorMessages.unknown;
   }
 
   Never _throwWithSnackBar(Exception error, {bool showErrorSnackBar = true}) {
@@ -103,11 +143,13 @@ class HttpService {
                 await req.send().timeout(const Duration(seconds: 90));
             response = await http.Response.fromStream(streamed);
           } else {
-            response = await http.post(
-              uri,
-              headers: mergedHeaders,
-              body: json.encode(body),
-            );
+            response = await http
+                .post(
+                  uri,
+                  headers: mergedHeaders,
+                  body: json.encode(body),
+                )
+                .timeout(const Duration(seconds: 30));
           }
           break;
 
@@ -160,9 +202,9 @@ class HttpService {
         TimeoutException(),
         showErrorSnackBar: showErrorSnackBar,
       );
-    } on FormatException catch (e) {
+    } on FormatException {
       _throwWithSnackBar(
-        ParseException(message: 'JSON Parsing Failed: ${e.message}'),
+        ParseException(message: ErrorMessages.parse),
         showErrorSnackBar: showErrorSnackBar,
       );
     } catch (error) {
@@ -178,7 +220,7 @@ class HttpService {
       }
       // 알 수 없는 에러는 일반적인 ApiException으로 래핑
       _throwWithSnackBar(
-        ApiException(message: 'Unknown error: $error'),
+        ApiException(message: ErrorMessages.unknown),
         showErrorSnackBar: showErrorSnackBar,
       );
     }
@@ -220,8 +262,7 @@ class HttpService {
         // 실패 응답인데 JSON이 아니면 에러 발생
         _throwWithSnackBar(
           ParseException(
-            message:
-                'Failed to parse response as JSON: ${utf8.decode(response.bodyBytes)}',
+            message: ErrorMessages.responseParse,
           ),
           showErrorSnackBar: showErrorSnackBar,
         );
@@ -235,9 +276,14 @@ class HttpService {
         : (rawErrorCode is String ? int.tryParse(rawErrorCode) : null);
 
     if (status < 200 || status >= 300) {
-      final message = decodedBody['message'] as String? ??
-          response.reasonPhrase ??
-          '알 수 없는 오류';
+      final serverMessage = decodedBody is Map
+          ? decodedBody['message'] as String?
+          : response.reasonPhrase;
+      final message = _safeResponseMessage(
+        status: status,
+        errorCode: errorCode,
+        rawMessage: serverMessage,
+      );
 
       // 토큰 만료 시 재시도 (status 401 또는 errorCode 1005)
       // requiredToken이 true이고, 아직 재시도하지 않았다면 토큰 갱신 후 재시도
@@ -319,5 +365,37 @@ class HttpService {
       return decodedBody['data'];
     }
     return decodedBody;
+  }
+
+  String _safeResponseMessage({
+    required int status,
+    required int? errorCode,
+    required String? rawMessage,
+  }) {
+    final statusFallback = _fallbackByStatus(status);
+    if (errorCode != null) {
+      return ErrorMessageMapper.byErrorCode(
+        errorCode: errorCode,
+        fallback: statusFallback,
+      );
+    }
+
+    return ErrorMessageMapper.sanitizeRawMessage(
+      rawMessage,
+      fallback: statusFallback,
+    );
+  }
+
+  String _fallbackByStatus(int status) {
+    if (status == 401 || status == 403) {
+      return ErrorMessages.authRequired;
+    }
+    if (status >= 400 && status < 500) {
+      return ErrorMessages.badRequest;
+    }
+    if (status >= 500) {
+      return ErrorMessages.server;
+    }
+    return ErrorMessages.unknown;
   }
 }

--- a/lib/Util/ApiHelper.dart
+++ b/lib/Util/ApiHelper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../Exception/ApiException.dart';
+import 'AppErrorReporter.dart';
 
 /// API 호출을 위한 공통 헬퍼 클래스
 /// 모든 API 호출에서 일관된 에러 처리와 사용자 피드백을 제공합니다.
@@ -26,6 +27,9 @@ class ApiHelper {
     String? successMessage,
     bool showErrorSnackBar = true,
     void Function(dynamic error)? onError,
+    String source = 'api_helper',
+    AppErrorSeverity severity = AppErrorSeverity.error,
+    bool sendToDiscord = true,
   }) async {
     try {
       final result = await apiCall();
@@ -42,85 +46,17 @@ class ApiHelper {
       }
 
       return result;
-    } on UnauthorizedException catch (e) {
-      if (showErrorSnackBar && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.getUserMessage()),
-            backgroundColor: Colors.red,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-        // 필요하다면 로그인 화면으로 이동
-        // Navigator.pushReplacementNamed(context, '/login');
-      }
-      onError?.call(e);
-    } on NetworkException catch (e) {
-      if (showErrorSnackBar && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.getUserMessage()),
-            backgroundColor: Colors.orange,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
-      onError?.call(e);
-    } on TimeoutException catch (e) {
-      if (showErrorSnackBar && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.getUserMessage()),
-            backgroundColor: Colors.orange,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
-      onError?.call(e);
-    } on ServerException catch (e) {
-      if (showErrorSnackBar && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.getUserMessage()),
-            backgroundColor: Colors.red,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
-      onError?.call(e);
-    } on BadRequestException catch (e) {
-      if (showErrorSnackBar && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.getUserMessage()),
-            backgroundColor: Colors.orange,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
-      onError?.call(e);
-    } on ApiException catch (e) {
-      if (showErrorSnackBar && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.getUserMessage()),
-            backgroundColor: Colors.red,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
-      onError?.call(e);
-    } catch (e) {
-      // 예상하지 못한 에러
-      if (showErrorSnackBar && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('알 수 없는 오류가 발생했습니다.'),
-            backgroundColor: Colors.red,
-            duration: Duration(seconds: 3),
-          ),
-        );
-      }
+    } catch (e, stackTrace) {
+      final messenger = context.mounted ? ScaffoldMessenger.of(context) : null;
+      await _handleError(
+        messenger,
+        e,
+        stackTrace,
+        showErrorSnackBar: showErrorSnackBar,
+        source: source,
+        severity: severity,
+        sendToDiscord: sendToDiscord,
+      );
       onError?.call(e);
     }
 
@@ -156,6 +92,9 @@ class ApiHelper {
     Future<T> Function() apiCall, {
     String? successMessage,
     bool showErrorSnackBar = true,
+    String source = 'api_helper',
+    AppErrorSeverity severity = AppErrorSeverity.error,
+    bool sendToDiscord = true,
   }) async {
     try {
       final result = await apiCall();
@@ -172,36 +111,17 @@ class ApiHelper {
       }
 
       return result;
-    } catch (e) {
-      // 에러 메시지 표시
-      if (showErrorSnackBar && context.mounted) {
-        String message = '알 수 없는 오류가 발생했습니다.';
-        Color backgroundColor = Colors.red;
-
-        if (e is UnauthorizedException ||
-            e is NetworkException ||
-            e is TimeoutException ||
-            e is ServerException ||
-            e is BadRequestException ||
-            e is ApiException) {
-          message = (e as dynamic).getUserMessage();
-          if (e is NetworkException || e is TimeoutException) {
-            backgroundColor = Colors.orange;
-          } else if (e is BadRequestException) {
-            backgroundColor = Colors.orange;
-          }
-        }
-
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(message),
-            backgroundColor: backgroundColor,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      }
-
-      // 에러를 다시 던짐
+    } catch (e, stackTrace) {
+      final messenger = context.mounted ? ScaffoldMessenger.of(context) : null;
+      await _handleError(
+        messenger,
+        e,
+        stackTrace,
+        showErrorSnackBar: showErrorSnackBar,
+        source: source,
+        severity: severity,
+        sendToDiscord: sendToDiscord,
+      );
       rethrow;
     }
   }
@@ -227,6 +147,9 @@ class ApiHelper {
     Future<T> Function() apiCall, {
     String? successMessage,
     String loadingMessage = '처리 중...',
+    String source = 'api_helper',
+    AppErrorSeverity severity = AppErrorSeverity.error,
+    bool sendToDiscord = true,
   }) async {
     // 로딩 다이얼로그 표시
     showDialog(
@@ -257,6 +180,9 @@ class ApiHelper {
         context,
         apiCall,
         successMessage: successMessage,
+        source: source,
+        severity: severity,
+        sendToDiscord: sendToDiscord,
       );
 
       // 로딩 다이얼로그 닫기
@@ -273,4 +199,63 @@ class ApiHelper {
       rethrow;
     }
   }
+
+  static Future<void> _handleError(
+    ScaffoldMessengerState? messenger,
+    Object error,
+    StackTrace stackTrace, {
+    required bool showErrorSnackBar,
+    required String source,
+    required AppErrorSeverity severity,
+    required bool sendToDiscord,
+  }) async {
+    await AppErrorReporter.report(
+      error,
+      stackTrace,
+      source: source,
+      severity: severity,
+      sendToDiscord: sendToDiscord,
+    );
+
+    if (showErrorSnackBar && messenger != null) {
+      final presentation = _errorPresentation(error);
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(presentation.message),
+          backgroundColor: presentation.backgroundColor,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    }
+  }
+
+  static _ErrorPresentation _errorPresentation(Object error) {
+    if (error is NetworkException) {
+      return _ErrorPresentation(error.getUserMessage(), Colors.orange);
+    }
+    if (error is TimeoutException) {
+      return _ErrorPresentation(error.getUserMessage(), Colors.orange);
+    }
+    if (error is BadRequestException) {
+      return _ErrorPresentation(error.getUserMessage(), Colors.orange);
+    }
+    if (error is UnauthorizedException) {
+      return _ErrorPresentation(error.getUserMessage(), Colors.red);
+    }
+    if (error is ServerException) {
+      return _ErrorPresentation(error.getUserMessage(), Colors.red);
+    }
+    if (error is ApiException) {
+      return _ErrorPresentation(error.getUserMessage(), Colors.red);
+    }
+
+    return const _ErrorPresentation('알 수 없는 오류가 발생했습니다.', Colors.red);
+  }
+}
+
+class _ErrorPresentation {
+  final String message;
+  final Color backgroundColor;
+
+  const _ErrorPresentation(this.message, this.backgroundColor);
 }

--- a/lib/Util/AppErrorReporter.dart
+++ b/lib/Util/AppErrorReporter.dart
@@ -1,0 +1,111 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'SendDiscordAlert.dart';
+
+enum AppErrorSeverity { warning, error, fatal }
+
+class AppErrorReporter {
+  static const String _appEnv = String.fromEnvironment(
+    'ENV',
+    defaultValue: 'local',
+  );
+
+  static Future<void> report(
+    Object error,
+    StackTrace stackTrace, {
+    String source = 'app',
+    AppErrorSeverity severity = AppErrorSeverity.error,
+    bool sendToDiscord = true,
+  }) async {
+    await _ensureDotenvLoaded();
+
+    developer.log(
+      '[${severity.name}] $source',
+      name: 'AppErrorReporter',
+      error: error,
+      stackTrace: stackTrace,
+    );
+
+    try {
+      await Sentry.captureException(error, stackTrace: stackTrace);
+    } catch (sentryError, sentryStackTrace) {
+      developer.log(
+        'Failed to report to Sentry',
+        name: 'AppErrorReporter',
+        error: sentryError,
+        stackTrace: sentryStackTrace,
+      );
+    }
+
+    if (!sendToDiscord) return;
+
+    final webhookUrl = _resolveDiscordWebhookUrl();
+    if (webhookUrl == null) {
+      developer.log(
+        'Discord webhook URL is not configured for env=$_appEnv',
+        name: 'AppErrorReporter',
+      );
+      return;
+    }
+
+    final result = await sendDiscordAlert(
+      message: '[$source] $error',
+      stack: stackTrace,
+      webhookUrl: webhookUrl,
+    );
+
+    if (!result.isSuccess) {
+      developer.log(
+        'Discord webhook failed'
+        '${result.statusCode != null ? ' status=${result.statusCode}' : ''}'
+        '${result.error != null ? ' error=${result.error}' : ''}',
+        name: 'AppErrorReporter',
+      );
+    }
+  }
+
+  static Future<void> _ensureDotenvLoaded() async {
+    if (dotenv.env.isNotEmpty) return;
+
+    try {
+      await dotenv.load(fileName: '.env');
+    } catch (error, stackTrace) {
+      developer.log(
+        'Failed to load dotenv for error reporting',
+        name: 'AppErrorReporter',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  static String? _resolveDiscordWebhookUrl() {
+    final prodUrl = _normalize(dotenv.env['DISCORD_WEBHOOK_PROD_URL']);
+    final localUrl = _normalize(dotenv.env['DISCORD_WEBHOOK_LOCAL_URL']);
+
+    switch (_appEnv) {
+      case 'prod':
+        return prodUrl ?? localUrl;
+      case 'dev':
+        return localUrl ?? prodUrl;
+      default:
+        if (kReleaseMode) {
+          return prodUrl ?? localUrl;
+        }
+        return localUrl ?? prodUrl;
+    }
+  }
+
+  static String? _normalize(String? value) {
+    if (value == null) return null;
+
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+
+    return trimmed;
+  }
+}

--- a/lib/Util/AppSnackBar.dart
+++ b/lib/Util/AppSnackBar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../Module/Text/StandardText.dart';
+import 'ErrorMessageMapper.dart';
 
 class AppSnackBar {
   static final GlobalKey<ScaffoldMessengerState> messengerKey =
@@ -11,22 +12,23 @@ class AppSnackBar {
   static void showError(String message) {
     final messenger = messengerKey.currentState;
     if (messenger == null || message.trim().isEmpty) return;
+    final safeMessage = ErrorMessageMapper.sanitizeRawMessage(message);
 
     final now = DateTime.now();
-    if (_lastMessage == message &&
+    if (_lastMessage == safeMessage &&
         _lastShownAt != null &&
         now.difference(_lastShownAt!) < const Duration(milliseconds: 800)) {
       return;
     }
 
-    _lastMessage = message;
+    _lastMessage = safeMessage;
     _lastShownAt = now;
 
     messenger.hideCurrentSnackBar();
     messenger.showSnackBar(
       SnackBar(
         content: StandardText(
-          text: message,
+          text: safeMessage,
           fontSize: 14,
           color: Colors.white,
         ),

--- a/lib/Util/ErrorMessageMapper.dart
+++ b/lib/Util/ErrorMessageMapper.dart
@@ -31,6 +31,7 @@ class ErrorMessageMapper {
   static String sanitizeRawMessage(
     String? raw, {
     String fallback = ErrorMessages.unknown,
+    bool allowRawMessage = false,
   }) {
     final message = (raw ?? '').trim();
     if (message.isEmpty) return fallback;
@@ -42,7 +43,7 @@ class ErrorMessageMapper {
     if (_looksLikeServer(lower)) return ErrorMessages.server;
     if (_looksLikeInternalRaw(lower)) return fallback;
 
-    return message;
+    return allowRawMessage ? message : fallback;
   }
 
   static bool _looksLikeTimeout(String lower) {

--- a/lib/Util/ErrorMessageMapper.dart
+++ b/lib/Util/ErrorMessageMapper.dart
@@ -1,48 +1,45 @@
+import '../Constants/ErrorMessages.dart';
+
 class ErrorMessageMapper {
-  static const String _unknownError = '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
-  static const String _networkError = '네트워크 연결이 원활하지 않습니다. 인터넷 상태를 확인해주세요.';
-  static const String _timeoutError = '요청 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.';
-  static const String _authError = '로그인이 필요합니다. 다시 로그인해주세요.';
-  static const String _serverError = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
   static String byErrorCode({required int? errorCode, String? fallback}) {
     switch (errorCode) {
       case 1001:
-        return '요청 형식이 올바르지 않습니다.';
+        return ErrorMessages.requestInvalid;
       case 1002:
-        return '필수 항목이 누락되었습니다.';
+        return ErrorMessages.requiredFieldMissing;
       case 1003:
-        return '요청한 데이터를 찾을 수 없습니다.';
+        return ErrorMessages.notFound;
       case 1004:
-        return '권한이 없습니다.';
+        return ErrorMessages.forbidden;
       case 1005:
-        return '세션이 만료되었습니다. 다시 로그인해주세요.';
+        return ErrorMessages.sessionExpired;
       case 9001:
-        return '태그 이름을 입력해주세요.';
+        return ErrorMessages.tagNameEmpty;
       case 9002:
-        return '태그 이름은 30자 이하여야 합니다.';
+        return ErrorMessages.tagNameTooLong;
       case 9003:
-        return '유효하지 않은 태그입니다.';
+        return ErrorMessages.tagNotFound;
       case 9004:
-        return '해당 태그에 접근할 수 없습니다.';
+        return ErrorMessages.tagUserUnmatched;
       case 9005:
-        return '문제당 태그는 최대 5개까지 설정할 수 있습니다.';
+        return ErrorMessages.tagLimitExceeded;
       default:
-        return fallback ?? _unknownError;
+        return fallback ?? ErrorMessages.unknown;
     }
   }
 
   static String sanitizeRawMessage(
     String? raw, {
-    String fallback = _unknownError,
+    String fallback = ErrorMessages.unknown,
   }) {
     final message = (raw ?? '').trim();
     if (message.isEmpty) return fallback;
 
     final lower = message.toLowerCase();
-    if (_looksLikeTimeout(lower)) return _timeoutError;
-    if (_looksLikeNetwork(lower)) return _networkError;
-    if (_looksLikeAuth(lower)) return _authError;
-    if (_looksLikeServer(lower)) return _serverError;
+    if (_looksLikeTimeout(lower)) return ErrorMessages.timeout;
+    if (_looksLikeNetwork(lower)) return ErrorMessages.network;
+    if (_looksLikeAuth(lower)) return ErrorMessages.authRequired;
+    if (_looksLikeServer(lower)) return ErrorMessages.server;
     if (_looksLikeInternalRaw(lower)) return fallback;
 
     return message;

--- a/lib/Util/ErrorMessageMapper.dart
+++ b/lib/Util/ErrorMessageMapper.dart
@@ -1,0 +1,90 @@
+class ErrorMessageMapper {
+  static const String _unknownError = '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+  static const String _networkError = '네트워크 연결이 원활하지 않습니다. 인터넷 상태를 확인해주세요.';
+  static const String _timeoutError = '요청 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.';
+  static const String _authError = '로그인이 필요합니다. 다시 로그인해주세요.';
+  static const String _serverError = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+  static String byErrorCode({required int? errorCode, String? fallback}) {
+    switch (errorCode) {
+      case 1001:
+        return '요청 형식이 올바르지 않습니다.';
+      case 1002:
+        return '필수 항목이 누락되었습니다.';
+      case 1003:
+        return '요청한 데이터를 찾을 수 없습니다.';
+      case 1004:
+        return '권한이 없습니다.';
+      case 1005:
+        return '세션이 만료되었습니다. 다시 로그인해주세요.';
+      case 9001:
+        return '태그 이름을 입력해주세요.';
+      case 9002:
+        return '태그 이름은 30자 이하여야 합니다.';
+      case 9003:
+        return '유효하지 않은 태그입니다.';
+      case 9004:
+        return '해당 태그에 접근할 수 없습니다.';
+      case 9005:
+        return '문제당 태그는 최대 5개까지 설정할 수 있습니다.';
+      default:
+        return fallback ?? _unknownError;
+    }
+  }
+
+  static String sanitizeRawMessage(
+    String? raw, {
+    String fallback = _unknownError,
+  }) {
+    final message = (raw ?? '').trim();
+    if (message.isEmpty) return fallback;
+
+    final lower = message.toLowerCase();
+    if (_looksLikeTimeout(lower)) return _timeoutError;
+    if (_looksLikeNetwork(lower)) return _networkError;
+    if (_looksLikeAuth(lower)) return _authError;
+    if (_looksLikeServer(lower)) return _serverError;
+    if (_looksLikeInternalRaw(lower)) return fallback;
+
+    return message;
+  }
+
+  static bool _looksLikeTimeout(String lower) {
+    return lower.contains('timeoutexception') ||
+        lower.contains('future not completed') ||
+        lower.contains('요청 시간이 초과');
+  }
+
+  static bool _looksLikeNetwork(String lower) {
+    return lower.contains('socketexception') ||
+        lower.contains('connection refused') ||
+        lower.contains('failed host lookup') ||
+        lower.contains('networkexception') ||
+        lower.contains('xmlhttprequest error') ||
+        lower.contains('network is unreachable');
+  }
+
+  static bool _looksLikeAuth(String lower) {
+    return lower.contains('unauthorizedexception') ||
+        lower.contains('authorization token') ||
+        lower.contains('refresh token') ||
+        lower.contains('로그인이 필요') ||
+        lower.contains('세션이 만료');
+  }
+
+  static bool _looksLikeServer(String lower) {
+    return lower.contains('serverexception') ||
+        lower.contains('status: 5') ||
+        lower.contains('http 5');
+  }
+
+  static bool _looksLikeInternalRaw(String lower) {
+    return lower.contains('exception:') ||
+        lower.contains('response:') ||
+        lower.contains('uri=') ||
+        lower.contains('json parsing failed') ||
+        lower.contains('failed to parse response') ||
+        lower.contains('unknown error:') ||
+        lower.contains('{') ||
+        lower.contains('<!doctype html');
+  }
+}

--- a/lib/Util/NotificationService.dart
+++ b/lib/Util/NotificationService.dart
@@ -2,10 +2,13 @@ import 'dart:developer';
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:ono/Config/AppConfig.dart';
 
+import '../Config/firebase_options.dart';
 import '../Service/Api/HttpService.dart';
+import 'AppErrorReporter.dart';
 
 class NotificationService {
   NotificationService._();
@@ -14,6 +17,7 @@ class NotificationService {
   final HttpService httpService = HttpService();
   final FirebaseMessaging _messaging = FirebaseMessaging.instance;
   final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
+  bool _tokenRefreshListenerConfigured = false;
 
   /// 앱 실행 시 한 번만 호출
   Future<void> init() async {
@@ -61,8 +65,21 @@ class NotificationService {
       // TODO: Navigator.pushNamed(...) 등으로 화면 이동
     });
 
-    // 앱 종료/백그라운드에서도 메시지를 처리
-    FirebaseMessaging.onBackgroundMessage(_firebaseBackgroundHandler);
+    if (!_tokenRefreshListenerConfigured) {
+      _tokenRefreshListenerConfigured = true;
+      _messaging.onTokenRefresh.listen((token) async {
+        try {
+          await _sendTokenValueToServer(token);
+        } catch (error, stackTrace) {
+          await AppErrorReporter.report(
+            error,
+            stackTrace,
+            source: 'fcm_token_refresh',
+            severity: AppErrorSeverity.warning,
+          );
+        }
+      });
+    }
   }
 
   Future<void> sendTokenToServer() async {
@@ -72,6 +89,10 @@ class NotificationService {
       return;
     }
 
+    await _sendTokenValueToServer(token);
+  }
+
+  Future<void> _sendTokenValueToServer(String token) async {
     await httpService.sendRequest(
       method: 'POST',
       url: '${AppConfig.baseUrl}/api/fcm/token',
@@ -84,7 +105,24 @@ class NotificationService {
 }
 
 /// 백그라운드/종료 상태에서 호출
-Future<void> _firebaseBackgroundHandler(RemoteMessage message) async {
-  log('Background message: ${message.notification?.title}');
-  // TODO: flutter_local_notifications로 로컬 알림 띄우기
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  try {
+    if (Firebase.apps.isEmpty) {
+      await Firebase.initializeApp(
+        name: 'OnO',
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    }
+
+    log('Background message: ${message.notification?.title}');
+    // TODO: flutter_local_notifications로 로컬 알림 띄우기
+  } catch (error, stackTrace) {
+    await AppErrorReporter.report(
+      error,
+      stackTrace,
+      source: 'fcm_background',
+      severity: AppErrorSeverity.error,
+    );
+  }
 }

--- a/lib/Util/SendDiscordAlert.dart
+++ b/lib/Util/SendDiscordAlert.dart
@@ -3,15 +3,34 @@ import 'dart:developer';
 
 import 'package:http/http.dart' as http;
 
+class DiscordAlertResult {
+  final bool isSuccess;
+  final int? statusCode;
+  final Object? error;
+
+  const DiscordAlertResult._({
+    required this.isSuccess,
+    this.statusCode,
+    this.error,
+  });
+
+  const DiscordAlertResult.success({int? statusCode})
+      : this._(isSuccess: true, statusCode: statusCode);
+
+  const DiscordAlertResult.failure({int? statusCode, Object? error})
+      : this._(isSuccess: false, statusCode: statusCode, error: error);
+}
+
 String _truncate(String text, int maxLength) {
   if (text.length <= maxLength) return text;
   return '${text.substring(0, maxLength - 3)}...';
 }
 
-Future<void> sendDiscordAlert({
+Future<DiscordAlertResult> sendDiscordAlert({
   required String message,
   StackTrace? stack,
   required String webhookUrl,
+  int maxAttempts = 2,
 }) async {
   // Discord embed 제한 대응
   final safeMessage = _truncate(message, 1500);
@@ -34,16 +53,53 @@ Future<void> sendDiscordAlert({
     'embeds': [embed]
   };
 
-  try {
-    final response = await http.post(
-      Uri.parse(webhookUrl),
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode(payload),
-    );
-    if (response.statusCode < 200 || response.statusCode >= 300) {
+  for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      final response = await http
+          .post(
+            Uri.parse(webhookUrl),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode(payload),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        return DiscordAlertResult.success(statusCode: response.statusCode);
+      }
+
       log('Discord webhook failed: ${response.statusCode} ${response.body}');
+
+      if (attempt < maxAttempts && response.statusCode == 429) {
+        await Future.delayed(_retryDelay(response.headers['retry-after']));
+        continue;
+      }
+
+      if (attempt < maxAttempts && response.statusCode >= 500) {
+        await Future.delayed(const Duration(seconds: 1));
+        continue;
+      }
+
+      return DiscordAlertResult.failure(statusCode: response.statusCode);
+    } catch (e) {
+      log('Failed to send Discord webhook: $e');
+
+      if (attempt < maxAttempts) {
+        await Future.delayed(const Duration(milliseconds: 500));
+        continue;
+      }
+
+      return DiscordAlertResult.failure(error: e);
     }
-  } catch (e) {
-    log('Failed to send Discord webhook: $e');
   }
+
+  return const DiscordAlertResult.failure();
+}
+
+Duration _retryDelay(String? retryAfterHeader) {
+  final retryAfterSeconds = int.tryParse(retryAfterHeader ?? '');
+  if (retryAfterSeconds == null || retryAfterSeconds < 1) {
+    return const Duration(seconds: 1);
+  }
+
+  return Duration(seconds: retryAfterSeconds);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:developer';
+import 'dart:ui';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
@@ -25,101 +25,114 @@ import 'Provider/UserProvider.dart';
 import 'Screen/Folder/DirectoryScreen.dart';
 import 'Screen/PracticeNote/PracticeThumbnailScreen.dart';
 import 'Screen/User/MyPageScreen.dart';
+import 'Util/AppErrorReporter.dart';
 import 'Util/NotificationService.dart';
 import 'Util/AppSnackBar.dart';
-import 'Util/SendDiscordAlert.dart';
-
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  // 앱 종료 상태에서도 이곳이 호출됩니다
-  log('🔔 백그라운드 메시지 받음: ${message.messageId}');
-  // (선택) flutter_local_notifications 등으로 로컬 알림 표시
-}
 
 void main() async {
-  runZonedGuarded<Future<void>>(
-    () async {
-      WidgetsFlutterBinding.ensureInitialized();
-      await dotenv.load(fileName: ".env");
-      await AppConfig.load();
+  WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: '.env');
 
-      await Firebase.initializeApp(
-        name: "OnO",
-        options: DefaultFirebaseOptions.currentPlatform,
-      );
-      await NotificationService.instance.init();
-      FirebaseMessaging.onBackgroundMessage(
-        _firebaseMessagingBackgroundHandler,
-      );
-
-      KakaoSdk.init(nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY']!);
-
-      await SentryFlutter.init((options) {
-        options.dsn = dotenv.env['SENTRY_DSN']!;
-        options.profilesSampleRate = 0.0;
-        options.tracesSampleRate = 1.0;
-      });
-      // FlutterError 처리기 설정
-      FlutterError.onError = (details) async {
-        FlutterError.dumpErrorToConsole(details);
-        final webhookUrl = kReleaseMode
-            ? dotenv.env['DISCORD_WEBHOOK_PROD_URL']!
-            : dotenv.env['DISCORD_WEBHOOK_LOCAL_URL']!;
-        Sentry.captureException(details.exception, stackTrace: details.stack);
-        await sendDiscordAlert(
-          message: details.exceptionAsString(),
-          stack: details.stack,
-          webhookUrl: webhookUrl,
+  await SentryFlutter.init(
+    (options) {
+      options.dsn = dotenv.env['SENTRY_DSN'] ?? '';
+      options.profilesSampleRate = 0.0;
+      options.tracesSampleRate = 1.0;
+    },
+    appRunner: () {
+      FlutterError.onError = (details) {
+        FlutterError.presentError(details);
+        unawaited(
+          AppErrorReporter.report(
+            details.exception,
+            details.stack ?? StackTrace.current,
+            source: 'flutter_error',
+            severity: AppErrorSeverity.fatal,
+          ),
         );
       };
 
-      runApp(
-        MultiProvider(
-          providers: [
-            ChangeNotifierProvider(create: (_) => ProblemsProvider()),
-            ChangeNotifierProvider(
-              create: (context) => FoldersProvider(
-                problemsProvider: Provider.of<ProblemsProvider>(
-                  context,
-                  listen: false,
-                ),
-              ),
+      PlatformDispatcher.instance.onError = (error, stackTrace) {
+        unawaited(
+          AppErrorReporter.report(
+            error,
+            stackTrace,
+            source: 'platform_dispatcher',
+            severity: AppErrorSeverity.fatal,
+          ),
+        );
+        return true;
+      };
+
+      runZonedGuarded<Future<void>>(
+        _bootstrapApp,
+        (error, stackTrace) async {
+          await AppErrorReporter.report(
+            error,
+            stackTrace,
+            source: 'zoned_guarded',
+            severity: AppErrorSeverity.fatal,
+          );
+        },
+      );
+    },
+  );
+}
+
+Future<void> _bootstrapApp() async {
+  await AppConfig.load();
+
+  if (Firebase.apps.where((app) => app.name == 'OnO').isEmpty) {
+    await Firebase.initializeApp(
+      name: 'OnO',
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  }
+
+  await NotificationService.instance.init();
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+
+  final kakaoNativeAppKey = dotenv.env['KAKAO_NATIVE_APP_KEY']?.trim();
+  if (kakaoNativeAppKey == null || kakaoNativeAppKey.isEmpty) {
+    log('KAKAO_NATIVE_APP_KEY is not configured.');
+  } else {
+    KakaoSdk.init(nativeAppKey: kakaoNativeAppKey);
+  }
+
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => ProblemsProvider()),
+        ChangeNotifierProvider(
+          create: (context) => FoldersProvider(
+            problemsProvider: Provider.of<ProblemsProvider>(
+              context,
+              listen: false,
             ),
-            ChangeNotifierProvider(
-              create: (context) => ProblemPracticeProvider(
-                problemsProvider: Provider.of<ProblemsProvider>(
-                  context,
-                  listen: false,
-                ),
-              ),
-            ),
-            ChangeNotifierProvider(
-              create: (context) => UserProvider(
-                Provider.of<ProblemsProvider>(context, listen: false),
-                Provider.of<FoldersProvider>(context, listen: false),
-                Provider.of<ProblemPracticeProvider>(context, listen: false),
-              ),
-            ),
-            ChangeNotifierProvider(
-              create: (context) => ThemeHandler()..loadColors(),
-            ),
-            ChangeNotifierProvider(create: (_) => ScreenIndexProvider()),
-          ],
-          child: const MyApp(),
+          ),
         ),
-      );
-    },
-    (error, stack) async {
-      // Zone 밖 비동기 예외 처리
-      final webhookUrl = kReleaseMode
-          ? dotenv.env['DISCORD_WEBHOOK_PROD_URL']!
-          : dotenv.env['DISCORD_WEBHOOK_LOCAL_URL']!;
-      Sentry.captureException(error, stackTrace: stack);
-      await sendDiscordAlert(
-        message: error.toString(),
-        stack: stack,
-        webhookUrl: webhookUrl,
-      );
-    },
+        ChangeNotifierProvider(
+          create: (context) => ProblemPracticeProvider(
+            problemsProvider: Provider.of<ProblemsProvider>(
+              context,
+              listen: false,
+            ),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => UserProvider(
+            Provider.of<ProblemsProvider>(context, listen: false),
+            Provider.of<FoldersProvider>(context, listen: false),
+            Provider.of<ProblemPracticeProvider>(context, listen: false),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (context) => ThemeHandler()..loadColors(),
+        ),
+        ChangeNotifierProvider(create: (_) => ScreenIndexProvider()),
+      ],
+      child: const MyApp(),
+    ),
   );
 }
 


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

> 서비스 예외 문구가 사용자에게 그대로 노출되는 문제를 줄이고, Sentry/Discord 기반 에러 추적 경로를 공통화했습니다.

- 사용자 노출용 에러 메시지를 공통 매핑으로 정리하고, 미등록 서버 메시지나 내부 예외 문구가 그대로 노출되지 않도록 보강했습니다.
- `AppErrorReporter`를 추가해 Sentry 캡처와 Discord Webhook 알림을 공통 경로로 통합했습니다.
- Discord Webhook 전송 실패/타임아웃이 앱 흐름을 막지 않도록 전송 결과를 안전하게 처리하도록 개선했습니다.
- HTTP 요청 실패, 타임아웃, 서버 에러, 인증 실패에 대한 사용자 메시지와 예외 분류를 보강했습니다.
- 로그인/게스트 로그인/자동 로그인/세션 복구 흐름에서 직접 Sentry 호출을 `AppErrorReporter`로 통일했습니다.
- access token, refresh token 등 민감값이 로그로 출력되지 않도록 제거했습니다.
- FCM 토큰 등록과 토큰 refresh 재전송 흐름을 보강해 알림 토큰 누락 가능성을 줄였습니다.
- 폴더, 문제 목록, 복습 노트, 문제 공유, 문제 등록/수정 등 주요 화면에서 조용히 삼키던 예외를 사용자 피드백과 리포팅 경로로 연결했습니다.
- 비동기 작업 후 `BuildContext` 사용 지점에 mounted 가드를 추가해 화면 이탈 중 snackbar/navigation이 실행되는 위험을 줄였습니다.
- 문제 등록/복습 인증 실패 시 로딩 다이얼로그가 남지 않도록 복구 순서를 개선했습니다.
- 문제 분석 폴링 실패를 리포팅하고, 반복 실패 시 폴링을 중단하도록 제한했습니다.
- `ApiHelper`에 `source`, `severity`, `sendToDiscord` 옵션을 추가해 공통 API 래퍼에서도 에러 리포팅이 가능하도록 확장했습니다.

### 검증

- `flutter analyze`를 변경 파일 중심으로 여러 차례 실행했습니다.
- 변경 파일 기준 컴파일 에러는 확인되지 않았습니다.
- 남아 있는 analyze 항목은 기존 파일명 규칙, `withOpacity` deprecated, 일부 unused 경고 계열입니다.
- `flutter test`는 기존 `test/widget_test.dart`가 `Provider<ThemeHandler>` 없이 `MyApp`을 렌더링하는 구조 문제로 실패합니다. 이번 변경으로 새로 발생한 실패로 보이지 않습니다.

### 스크린샷 (선택)

- UI 시각 변경 없음
