### PR TITLE
[Feat] 복습 세트 명칭 변경 및 UX 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ app.*.map.json
 .env
 BUILD_COMMANDS.md
 AGENTS.md
+.claude.md
 *.orig
 *.rej
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 | --- | --- | --- |
 | 2026/2/17 | V3.2.0 업데이트 | - 복습 기록 기능 도입 <br> - 대규모 디자인 개선 |
 | 2026/1/29 | V3.1.0 업데이트 | - 캐릭터 성장 기능 도입 |
-| 2026/1/22 | V3.0.0 업데이트 | - 레벨 제도 도입 <br> - 복습노트 알림 기능 도입 <br> - 오답노트 이미지 등록 편의성 개선|
+| 2026/1/22 | V3.0.0 업데이트 | - 레벨 제도 도입 <br> - 복습 세트 알림 기능 도입 <br> - 오답노트 이미지 등록 편의성 개선|
 | 2026/1/22 | **✨ 서비스 재개 ✨** | **OnO가 새롭게 개선되어 돌아왔어요!**|
 | 2024/12/4 | **‼️ 서비스 중지 ‼️** | **개선된 OnO로 돌아오기 위해 잠시 서비스를 중단합니다!**|
 | 2024/11/7 | V2.4.0 업데이트 | - 복습 리스트 기능 도입 ✨ |
@@ -91,8 +91,8 @@
 |---|---|---|---|---|
 |소셜 로그인|<img width="220" alt="image" src="https://github.com/user-attachments/assets/7cfc0061-d8cc-422f-ae43-fa40353698bb" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/24b0ee35-6a61-4ffc-a236-c973aa52368e" />|
 |오답노트 작성|<img width="220" alt="image" src="https://github.com/user-attachments/assets/656f26bf-8f05-47b7-aa5c-cd4826d8320c" />| <img width="220" alt="image" src="https://github.com/user-attachments/assets/a09c9d02-f004-421c-b14e-32b8a5c76dc2" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/c283b17b-a9b4-4b05-97e4-32a610296292" />|
-|복습노트 생성|<img width="220" alt="image" src="https://github.com/user-attachments/assets/7f20c547-c812-4524-b26e-55636c6f46ca" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/cc9f3985-d2cb-43be-96a5-d52ae73201c5" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/471dcfac-4df3-48fc-8702-da70d576f7e1" />|
-|복습노트 실행|<img width="220" alt="image" src="https://github.com/user-attachments/assets/1ac3827a-8b49-4836-8c39-26eb476f9bd9" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/4e0614dd-f5a8-4722-83dd-7bdd6438dac0" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/53434407-b1b0-4e32-bba8-374e6b98bcf9" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/4cb0c88e-01c8-437a-a85c-d6c57055b072" />|
+|복습 세트 생성|<img width="220" alt="image" src="https://github.com/user-attachments/assets/7f20c547-c812-4524-b26e-55636c6f46ca" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/cc9f3985-d2cb-43be-96a5-d52ae73201c5" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/471dcfac-4df3-48fc-8702-da70d576f7e1" />|
+|복습 세트 실행|<img width="220" alt="image" src="https://github.com/user-attachments/assets/1ac3827a-8b49-4836-8c39-26eb476f9bd9" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/4e0614dd-f5a8-4722-83dd-7bdd6438dac0" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/53434407-b1b0-4e32-bba8-374e6b98bcf9" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/4cb0c88e-01c8-437a-a85c-d6c57055b072" />|
 |오답 복습|<img width="220" alt="image" src="https://github.com/user-attachments/assets/b0038427-1e8f-461e-a1a8-ab0ed39d6ad2" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/2aea42ae-cac7-46ec-ad1f-bf5fad153437" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/8d9f244d-ceb9-4880-8966-4bce5ed07a08" />|<img width="220" alt="image" src="https://github.com/user-attachments/assets/4c8e7cff-3171-408b-a9a1-df32e508a64b" />|
 <br>
 

--- a/lib/Constants/ErrorMessages.dart
+++ b/lib/Constants/ErrorMessages.dart
@@ -14,6 +14,42 @@ class ErrorMessages {
   static const String forbidden = '권한이 없습니다.';
   static const String sessionExpired = '세션이 만료되었습니다. 다시 로그인해주세요.';
 
+  static const String invalidRefreshToken = '유효하지 않은 리프레시토큰입니다.';
+  static const String refreshTokenNotFound = '리프레시 토큰 정보를 찾을 수 없습니다.';
+  static const String invalidAuthority = '유효하지 않은 권한입니다.';
+  static const String refreshTokenNotEqual = '리프레시 토큰이 일치하지 않습니다.';
+  static const String accessTokenExpired = '엑세스 토큰이 만료되었습니다.';
+  static const String refreshTokenExpired = '리프레시 토큰이 만료되었습니다.';
+  static const String authenticationFailed = '인증이 실패했습니다.';
+  static const String accessDenied = '접근 권한이 없습니다.';
+  static const String invalidAccessToken = '유효하지 않은 엑세스 토큰입니다.';
+
+  static const String fileUploadFailed = '파일 업로드 중 문제가 발생했습니다.';
+
+  static const String userNotFound = '사용자를 찾을 수 없습니다.';
+
+  static const String problemNotFound = '문제를 찾을 수 없습니다.';
+  static const String problemUserUnmatched = '문제 작성자가 아닙니다.';
+  static const String problemSolveImageAlreadyRegistered =
+      '이미 오늘의 복습을 완료한 문제입니다.';
+  static const String problemAnalysisNotFound = '문제 분석 결과를 찾을 수 없습니다.';
+
+  static const String problemSolveNotFound = '복습 기록을 찾을 수 없습니다.';
+  static const String problemSolveUserUnmatched = '해당 복습 기록에 대한 권한이 없습니다.';
+
+  static const String folderNotFound = '폴더를 찾을 수 없습니다.';
+  static const String folderUserUnmatched = '폴더를 소유한 유저가 아닙니다.';
+  static const String rootFolderNotExist = '루트 폴더가 존재하지 않습니다.';
+  static const String rootFolderCannotRemove = '루트 폴더는 삭제할 수 없습니다.';
+
+  static const String practiceNoteNotFound = '복습 노트를 찾을 수 없습니다.';
+
+  static const String missionTypeNotFound = '잘못된 미션 종류입니다.';
+  static const String missionUserNotFound = '해당하는 유저가 존재하지 않습니다.';
+
+  static const String fcmTokenNotFound = 'Fcm Token을 찾을 수 없습니다.';
+  static const String fcmSendFailed = 'Fcm 메시지 전송에 실패했습니다.';
+
   static const String tagNameEmpty = '태그 이름을 입력해주세요.';
   static const String tagNameTooLong = '태그 이름은 30자 이하여야 합니다.';
   static const String tagNotFound = '유효하지 않은 태그입니다.';

--- a/lib/Constants/ErrorMessages.dart
+++ b/lib/Constants/ErrorMessages.dart
@@ -42,7 +42,7 @@ class ErrorMessages {
   static const String rootFolderNotExist = '루트 폴더가 존재하지 않습니다.';
   static const String rootFolderCannotRemove = '루트 폴더는 삭제할 수 없습니다.';
 
-  static const String practiceNoteNotFound = '복습 노트를 찾을 수 없습니다.';
+  static const String practiceNoteNotFound = '복습 세트를 찾을 수 없습니다.';
 
   static const String missionTypeNotFound = '잘못된 미션 종류입니다.';
   static const String missionUserNotFound = '해당하는 유저가 존재하지 않습니다.';

--- a/lib/Exception/ApiException.dart
+++ b/lib/Exception/ApiException.dart
@@ -60,15 +60,24 @@ class TimeoutException implements Exception {
 
 /// 인증 관련 예외
 class UnauthorizedException implements Exception {
+  final int? errorCode;
   final String message;
 
-  UnauthorizedException({this.message = ErrorMessages.authRequired});
+  UnauthorizedException({
+    this.errorCode,
+    this.message = ErrorMessages.authRequired,
+  });
 
   @override
-  String toString() => 'UnauthorizedException: $message';
+  String toString() => 'UnauthorizedException(errorCode: $errorCode): $message';
 
-  String getUserMessage() => ErrorMessageMapper.sanitizeRawMessage(message,
-      fallback: ErrorMessages.authRequired);
+  String getUserMessage() => ErrorMessageMapper.byErrorCode(
+        errorCode: errorCode,
+        fallback: ErrorMessageMapper.sanitizeRawMessage(
+          message,
+          fallback: ErrorMessages.authRequired,
+        ),
+      );
 }
 
 /// 서버 내부 오류 예외

--- a/lib/Module/Theme/ThemeLockManager.dart
+++ b/lib/Module/Theme/ThemeLockManager.dart
@@ -7,7 +7,7 @@ import '../../Model/User/UserInfoModel.dart';
 /// - 1, 5, 9, 13, 17, 21: 출석 레벨 기반
 /// - 2, 6, 10, 14, 18, 22: 오답노트 작성 레벨 기반
 /// - 3, 7, 11, 15, 19, 23: 오답노트 복습 레벨 기반
-/// - 4, 8, 12, 16, 20, 24: 복습노트 복습 레벨 기반
+/// - 4, 8, 12, 16, 20, 24: 복습 세트 복습 레벨 기반
 /// - 첫 행(1-4번)은 기본적으로 모두 잠금 해제
 class ThemeLockManager {
   // 각 테마의 색상 (원래 ThemeDialog 순서 그대로)
@@ -81,7 +81,7 @@ class ThemeLockManager {
   /// 1, 5, 9, 13, 17, 21 → 0 (출석)
   /// 2, 6, 10, 14, 18, 22 → 1 (노트작성)
   /// 3, 7, 11, 15, 19, 23 → 2 (오답복습)
-  /// 4, 8, 12, 16, 20, 24 → 3 (복습노트)
+  /// 4, 8, 12, 16, 20, 24 → 3 (복습 세트)
   static int getCategoryIndex(int themeIndex) {
     return themeIndex % 4;
   }
@@ -129,7 +129,7 @@ class ThemeLockManager {
       case 2: // 오답노트 복습 레벨 (3, 7, 11, 15, 19, 23)
         userLevel = userInfo.problemPracticeLevel;
         break;
-      case 3: // 복습노트 복습 레벨 (4, 8, 12, 16, 20, 24)
+      case 3: // 복습 세트 복습 레벨 (4, 8, 12, 16, 20, 24)
         userLevel = userInfo.notePracticeLevel;
         break;
       default:
@@ -159,7 +159,7 @@ class ThemeLockManager {
       case 2:
         return '문제 복습';
       case 3:
-        return '복습노트 복습';
+        return '복습 세트 복습';
       default:
         return '';
     }

--- a/lib/Provider/FoldersProvider.dart
+++ b/lib/Provider/FoldersProvider.dart
@@ -183,8 +183,14 @@ class FoldersProvider with ChangeNotifier {
   }
 
   // 폴더 메타데이터만 fetch (이름, 부모폴더 등)
-  Future<void> fetchFolderMetadata(int folderId) async {
-    final folder = await folderService.fetchFolder(folderId);
+  Future<void> fetchFolderMetadata(
+    int folderId, {
+    bool showErrorSnackBar = true,
+  }) async {
+    final folder = await folderService.fetchFolder(
+      folderId,
+      showErrorSnackBar: showErrorSnackBar,
+    );
     _upsertFolder(folder);
     log('Folder metadata fetched: $folderId');
     notifyListeners();
@@ -335,7 +341,13 @@ class FoldersProvider with ChangeNotifier {
         await folderService.registerFolder(folderRegisterModel);
 
     // 생성된 폴더 메타데이터 fetch
-    await fetchFolderMetadata(createdFolderId);
+    await _runPostMutationRefresh(
+      () => fetchFolderMetadata(
+        createdFolderId,
+        showErrorSnackBar: false,
+      ),
+      source: 'folder_create_metadata_refresh',
+    );
 
     // 부모 폴더의 캐시 갱신 (하위 폴더 목록 다시 로드)
     await refreshFolder(parentFolderId);
@@ -355,7 +367,13 @@ class FoldersProvider with ChangeNotifier {
     await folderService.updateFolderInfo(folderRegisterModel);
 
     // 메타데이터 갱신
-    await fetchFolderMetadata(folderId);
+    await _runPostMutationRefresh(
+      () => fetchFolderMetadata(
+        folderId,
+        showErrorSnackBar: false,
+      ),
+      source: 'folder_update_metadata_refresh',
+    );
 
     // 부모 폴더 캐시 갱신
     if (parentId != null) {
@@ -397,6 +415,23 @@ class FoldersProvider with ChangeNotifier {
   Future<void> refreshCurrentFolder() async {
     if (_currentFolder == null) return;
     await refreshFolder(_currentFolder!.folderId);
+  }
+
+  Future<void> _runPostMutationRefresh(
+    Future<void> Function() refresh, {
+    required String source,
+  }) async {
+    try {
+      await refresh();
+    } catch (e, stackTrace) {
+      log('Post-mutation refresh failed ($source): $e');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: source,
+        severity: AppErrorSeverity.warning,
+      );
+    }
   }
 
   // 캐시 전체 초기화 (로그아웃 시 등)

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -34,7 +34,7 @@ class ProblemPracticeProvider with ChangeNotifier {
   final PracticeNoteService practiceNoteService = PracticeNoteService();
   final ProblemsProvider problemsProvider;
 
-  // 복습 노트 목록 새로고침 타임스탬프
+  // 복습 세트 목록 새로고침 타임스탬프
   int _practiceRefreshTimestamp = 0;
   int get practiceRefreshTimestamp => _practiceRefreshTimestamp;
 
@@ -76,7 +76,7 @@ class ProblemPracticeProvider with ChangeNotifier {
 
     _upsertPracticeNote(practiceNote);
 
-    // 현재 복습노트가 업데이트된 것이면 다시 로드
+    // 현재 복습 세트가 업데이트된 것이면 다시 로드
     if (currentPracticeNote != null) {
       if (practiceNoteId == currentPracticeNote!.practiceId) {
         await moveToPractice(practiceNoteId);
@@ -103,7 +103,7 @@ class ProblemPracticeProvider with ChangeNotifier {
 
     currentProblems.clear();
 
-    // 복습 노트의 각 문제를 서버에서 조회 (지연 로딩 대응)
+    // 복습 세트의 각 문제를 서버에서 조회 (지연 로딩 대응)
     for (var problemId in targetPractice.problemIdList) {
       try {
         // 먼저 로컬 캐시에서 찾아보기
@@ -142,7 +142,7 @@ class ProblemPracticeProvider with ChangeNotifier {
 
     await fetchPracticeNote(createdPracticeId);
 
-    // 복습 노트 목록 새로고침 신호
+    // 복습 세트 목록 새로고침 신호
     _practiceRefreshTimestamp = DateTime.now().millisecondsSinceEpoch;
     log('Practice list refresh signaled - timestamp: $_practiceRefreshTimestamp');
     notifyListeners();
@@ -154,7 +154,7 @@ class ProblemPracticeProvider with ChangeNotifier {
 
     await fetchPracticeNote(practiceNoteUpdateModel.practiceNoteId);
 
-    // 복습 노트 목록 새로고침 신호
+    // 복습 세트 목록 새로고침 신호
     _practiceRefreshTimestamp = DateTime.now().millisecondsSinceEpoch;
     log('Practice list refresh signaled - timestamp: $_practiceRefreshTimestamp');
     notifyListeners();
@@ -197,14 +197,14 @@ class ProblemPracticeProvider with ChangeNotifier {
   }
 
   Future<void> fetchPracticeCount(int practiceNoteId) async {
-    // 서버에서 최신 복습 노트 정보 조회
+    // 서버에서 최신 복습 세트 정보 조회
     await fetchPracticeNote(practiceNoteId);
     log('복습 카운트 갱신 완료 - Practice ID: $practiceNoteId');
   }
 
   // ==================== V2 무한 스크롤 메서드들 ====================
 
-  /// 첫 페이지 복습 노트 썸네일 로드 (캐시 우선 사용)
+  /// 첫 페이지 복습 세트 썸네일 로드 (캐시 우선 사용)
   Future<void> loadInitialPracticeThumbnails(
       {int size = 20, bool forceRefresh = false}) async {
     // 캐시가 있고 강제 새로고침이 아니면 캐시 사용
@@ -243,7 +243,7 @@ class ProblemPracticeProvider with ChangeNotifier {
     }
   }
 
-  /// 다음 페이지 복습 노트 썸네일 로드 (무한 스크롤)
+  /// 다음 페이지 복습 세트 썸네일 로드 (무한 스크롤)
   Future<void> loadMorePracticeThumbnails({int size = 20}) async {
     if (_isLoading) return;
     if (!_hasNext || _nextCursor == null) return;
@@ -273,12 +273,12 @@ class ProblemPracticeProvider with ChangeNotifier {
     }
   }
 
-  /// 복습 노트 목록 새로고침 (캐시 무시)
+  /// 복습 세트 목록 새로고침 (캐시 무시)
   Future<void> refreshPracticeThumbnails() async {
     await loadInitialPracticeThumbnails(forceRefresh: true);
   }
 
-  /// 특정 복습 노트만 썸네일 캐시에서 업데이트
+  /// 특정 복습 세트만 썸네일 캐시에서 업데이트
   Future<void> updateSinglePracticeThumbnail(int practiceId) async {
     try {
       log('🔄 Updating single practice thumbnail: $practiceId');

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -172,6 +172,26 @@ class ProblemPracticeProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  void useRegisteredProblemOrder() {
+    final practiceNote = currentPracticeNote;
+    if (practiceNote == null) return;
+
+    final problemById = {
+      for (final problem in currentProblems) problem.problemId: problem,
+    };
+
+    currentProblems = practiceNote.problemIdList
+        .map((problemId) => problemById[problemId])
+        .whereType<ProblemModel>()
+        .toList();
+    notifyListeners();
+  }
+
+  void shuffleCurrentProblems() {
+    currentProblems.shuffle();
+    notifyListeners();
+  }
+
   Future<void> resetProblems() async {
     currentProblems = [];
     notifyListeners();

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -70,9 +70,14 @@ class ProblemPracticeProvider with ChangeNotifier {
     throw Exception('Practice with id $practiceNoteId not found.');
   }
 
-  Future<void> fetchPracticeNote(int? practiceNoteId) async {
-    final practiceNote =
-        await practiceNoteService.getPracticeNoteById(practiceNoteId!);
+  Future<void> fetchPracticeNote(
+    int? practiceNoteId, {
+    bool showErrorSnackBar = true,
+  }) async {
+    final practiceNote = await practiceNoteService.getPracticeNoteById(
+      practiceNoteId!,
+      showErrorSnackBar: showErrorSnackBar,
+    );
 
     _upsertPracticeNote(practiceNote);
 
@@ -140,7 +145,13 @@ class ProblemPracticeProvider with ChangeNotifier {
     int createdPracticeId = await practiceNoteService
         .registerPracticeNote(practiceNoteRegisterModel);
 
-    await fetchPracticeNote(createdPracticeId);
+    await _runPostMutationRefresh(
+      () => fetchPracticeNote(
+        createdPracticeId,
+        showErrorSnackBar: false,
+      ),
+      source: 'practice_register_refresh',
+    );
 
     // 복습 세트 목록 새로고침 신호
     _practiceRefreshTimestamp = DateTime.now().millisecondsSinceEpoch;
@@ -151,7 +162,7 @@ class ProblemPracticeProvider with ChangeNotifier {
   Future<void> updatePractice(
     PracticeNoteUpdateModel practiceNoteUpdateModel, {
     bool refreshAfterUpdate = true,
-    bool showErrorSnackBar = true,
+    bool showErrorSnackBar = false,
   }) async {
     await practiceNoteService.updatePracticeNote(
       practiceNoteUpdateModel,
@@ -159,7 +170,13 @@ class ProblemPracticeProvider with ChangeNotifier {
     );
 
     if (refreshAfterUpdate) {
-      await fetchPracticeNote(practiceNoteUpdateModel.practiceNoteId);
+      await _runPostMutationRefresh(
+        () => fetchPracticeNote(
+          practiceNoteUpdateModel.practiceNoteId,
+          showErrorSnackBar: false,
+        ),
+        source: 'practice_update_refresh',
+      );
     } else {
       _applyPracticeUpdateToCache(practiceNoteUpdateModel);
     }
@@ -183,6 +200,23 @@ class ProblemPracticeProvider with ChangeNotifier {
     practiceNote.problemIdList.removeWhere(
       (problemId) => updateModel.removeProblemIdList.contains(problemId),
     );
+  }
+
+  Future<void> _runPostMutationRefresh(
+    Future<void> Function() refresh, {
+    required String source,
+  }) async {
+    try {
+      await refresh();
+    } catch (e, stackTrace) {
+      log('Post-mutation refresh failed ($source): $e');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: source,
+        severity: AppErrorSeverity.warning,
+      );
+    }
   }
 
   Future<void> deletePractices(List<int> deletePracticeIds) async {

--- a/lib/Provider/PracticeNoteProvider.dart
+++ b/lib/Provider/PracticeNoteProvider.dart
@@ -149,15 +149,40 @@ class ProblemPracticeProvider with ChangeNotifier {
   }
 
   Future<void> updatePractice(
-      PracticeNoteUpdateModel practiceNoteUpdateModel) async {
-    await practiceNoteService.updatePracticeNote(practiceNoteUpdateModel);
+    PracticeNoteUpdateModel practiceNoteUpdateModel, {
+    bool refreshAfterUpdate = true,
+    bool showErrorSnackBar = true,
+  }) async {
+    await practiceNoteService.updatePracticeNote(
+      practiceNoteUpdateModel,
+      showErrorSnackBar: showErrorSnackBar,
+    );
 
-    await fetchPracticeNote(practiceNoteUpdateModel.practiceNoteId);
+    if (refreshAfterUpdate) {
+      await fetchPracticeNote(practiceNoteUpdateModel.practiceNoteId);
+    } else {
+      _applyPracticeUpdateToCache(practiceNoteUpdateModel);
+    }
 
     // 복습 세트 목록 새로고침 신호
     _practiceRefreshTimestamp = DateTime.now().millisecondsSinceEpoch;
     log('Practice list refresh signaled - timestamp: $_practiceRefreshTimestamp');
     notifyListeners();
+  }
+
+  void _applyPracticeUpdateToCache(PracticeNoteUpdateModel updateModel) {
+    final practiceNote = _practicesMap[updateModel.practiceNoteId];
+    if (practiceNote == null) return;
+
+    for (final problemId in updateModel.addProblemIdList) {
+      if (!practiceNote.problemIdList.contains(problemId)) {
+        practiceNote.problemIdList.add(problemId);
+      }
+    }
+
+    practiceNote.problemIdList.removeWhere(
+      (problemId) => updateModel.removeProblemIdList.contains(problemId),
+    );
   }
 
   Future<void> deletePractices(List<int> deletePracticeIds) async {

--- a/lib/Provider/ProblemsProvider.dart
+++ b/lib/Provider/ProblemsProvider.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:camera/camera.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:ono/Model/Common/PaginatedResponse.dart';
-import 'package:ono/Model/Problem/ProblemAnalysisStatus.dart';
 import 'package:ono/Model/Problem/ProblemModel.dart';
 import 'package:ono/Service/Api/Problem/ProblemService.dart';
 
@@ -44,8 +43,14 @@ class ProblemsProvider with ChangeNotifier {
     _problemsMap[problem.problemId] = problem;
   }
 
-  Future<void> fetchProblem(int problemId) async {
-    final fetchedProblem = await problemService.getProblem(problemId);
+  Future<void> fetchProblem(
+    int problemId, {
+    bool showErrorSnackBar = true,
+  }) async {
+    final fetchedProblem = await problemService.getProblem(
+      problemId,
+      showErrorSnackBar: showErrorSnackBar,
+    );
     _upsertProblem(fetchedProblem);
     log('problem: $problemId fetch complete');
     notifyListeners();
@@ -66,12 +71,28 @@ class ProblemsProvider with ChangeNotifier {
   Future<void> registerProblem(
       ProblemRegisterModel problemData, BuildContext context) async {
     int registerProblemId = await problemService.registerProblem(problemData);
-    await fetchProblem(registerProblemId);
+    await _runPostMutationRefresh(
+      () => fetchProblem(
+        registerProblemId,
+        showErrorSnackBar: false,
+      ),
+      source: 'problem_register_refresh',
+    );
 
-    int userProblemCount = await getUserProblemCount();
-    _problemCount = userProblemCount;
+    await _runPostMutationRefresh(
+      () async {
+        int userProblemCount = await getUserProblemCount(
+          showErrorSnackBar: false,
+        );
+        _problemCount = userProblemCount;
+      },
+      source: 'problem_register_count_refresh',
+    );
 
-    await requestReview(context);
+    await _runPostMutationRefresh(
+      () => requestReview(context),
+      source: 'problem_register_review_request',
+    );
 
     log('register problem id: $registerProblemId complete');
     notifyListeners();
@@ -114,14 +135,22 @@ class ProblemsProvider with ChangeNotifier {
       problemImageTypes: problemImageTypes,
     );
 
-    await fetchProblem(problemId);
+    await _runPostMutationRefresh(
+      () => fetchProblem(
+        problemId,
+        showErrorSnackBar: false,
+      ),
+      source: 'problem_image_register_refresh',
+    );
 
     log('register problem id: $problemId complete');
     notifyListeners();
   }
 
-  Future<int> getUserProblemCount() async {
-    return await problemService.getProblemCount();
+  Future<int> getUserProblemCount({bool showErrorSnackBar = true}) async {
+    return await problemService.getProblemCount(
+      showErrorSnackBar: showErrorSnackBar,
+    );
   }
 
   Future<void> updateProblem(ProblemRegisterModel problemData) async {
@@ -140,7 +169,13 @@ class ProblemsProvider with ChangeNotifier {
         await problemService.updateProblemPath(problemData);
       }
 
-      await fetchProblem(problemData.problemId!);
+      await _runPostMutationRefresh(
+        () => fetchProblem(
+          problemData.problemId!,
+          showErrorSnackBar: false,
+        ),
+        source: 'problem_update_refresh',
+      );
     } catch (e, stackTrace) {
       log('오답노트 수정 실패 - Problem ID: ${problemData.problemId}');
       log('에러: $e');
@@ -168,7 +203,14 @@ class ProblemsProvider with ChangeNotifier {
     }
 
     // 문제 개수 업데이트
-    _problemCount = await getUserProblemCount();
+    await _runPostMutationRefresh(
+      () async {
+        _problemCount = await getUserProblemCount(
+          showErrorSnackBar: false,
+        );
+      },
+      source: 'problem_delete_count_refresh',
+    );
 
     log('Deleted ${deleteProblemIdList.length} problems from cache');
     notifyListeners();
@@ -191,6 +233,23 @@ class ProblemsProvider with ChangeNotifier {
     final ReviewHandler reviewHandler = ReviewHandler();
     if (_problemCount > 0 && _problemCount % 10 == 0) {
       reviewHandler.requestReview(context);
+    }
+  }
+
+  Future<void> _runPostMutationRefresh(
+    Future<void> Function() refresh, {
+    required String source,
+  }) async {
+    try {
+      await refresh();
+    } catch (e, stackTrace) {
+      log('Post-mutation refresh failed ($source): $e');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: source,
+        severity: AppErrorSeverity.warning,
+      );
     }
   }
 

--- a/lib/Provider/TokenProvider.dart
+++ b/lib/Provider/TokenProvider.dart
@@ -130,7 +130,10 @@ class TokenProvider {
       if (response.statusCode == 401 || isRefreshTokenInvalid) {
         await deleteToken();
         await _notifyAuthFailure();
-        throw UnauthorizedException(message: errorMessage);
+        throw UnauthorizedException(
+          errorCode: errorCode,
+          message: errorMessage,
+        );
       }
       throw ApiException(
         statusCode: response.statusCode,
@@ -166,10 +169,16 @@ class TokenProvider {
   }) {
     final normalizedMessage = message.toLowerCase();
     final isRefreshTokenMessage = normalizedMessage.contains('리프레시 토큰') ||
+        normalizedMessage.contains('리프레시토큰') ||
         normalizedMessage.contains('refresh token');
     // 서버 구현에 따라 400 + 리프레시 토큰 메시지로 내려오는 케이스를 인증 만료로 처리
     return (statusCode == 400 || statusCode == 403) &&
-        (isRefreshTokenMessage || errorCode == 1005);
+        (isRefreshTokenMessage ||
+            errorCode == 1001 ||
+            errorCode == 1002 ||
+            errorCode == 1003 ||
+            errorCode == 1004 ||
+            errorCode == 1006);
   }
 
   bool _isTokenExpiringSoon(String token, Duration threshold) {

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -248,8 +248,10 @@ class UserProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> fetchUserInfo() async {
-    userInfoModel = await userService.fetchUserInfo();
+  Future<void> fetchUserInfo({bool showErrorSnackBar = true}) async {
+    userInfoModel = await userService.fetchUserInfo(
+      showErrorSnackBar: showErrorSnackBar,
+    );
     notifyListeners();
   }
 
@@ -266,7 +268,10 @@ class UserProvider with ChangeNotifier {
     );
 
     await userService.updateUserProfile(updateUserRegisterModel);
-    await fetchUserInfo();
+    await _runPostMutationRefresh(
+      () => fetchUserInfo(showErrorSnackBar: false),
+      source: 'user_update_info_refresh',
+    );
   }
 
   Future<void> autoLogin() async {
@@ -399,6 +404,23 @@ class UserProvider with ChangeNotifier {
     foldersProvider.clear();
     practiceProvider.clear();
     notifyListeners();
+  }
+
+  Future<void> _runPostMutationRefresh(
+    Future<void> Function() refresh, {
+    required String source,
+  }) async {
+    try {
+      await refresh();
+    } catch (e, stackTrace) {
+      log('Post-mutation refresh failed ($source): $e');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: source,
+        severity: AppErrorSeverity.warning,
+      );
+    }
   }
 
   Future<void> _handleAuthFailure() async {

--- a/lib/Screen/Folder/UserGuideScreen.dart
+++ b/lib/Screen/Folder/UserGuideScreen.dart
@@ -66,7 +66,7 @@ class _UserGuideScreenState extends State<UserGuideScreen> {
                 _buildUserGuidePage(
                   imagePath: 'assets/GuideScreen/GuideScreen4.svg',
                   title: '오답 복습',
-                  description: '작성한 오답노트로 복습 노트를 만들어\n필요한 문제만 빠르게 복습하세요.',
+                  description: '작성한 오답노트로 복습 세트를 만들어\n필요한 문제만 빠르게 복습하세요.',
                 ),
                 _buildUserGuidePage(
                   imagePath: 'assets/GuideScreen/GuideScreen5.svg',

--- a/lib/Screen/PracticeNote/PracticeDetailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeDetailScreen.dart
@@ -434,7 +434,8 @@ class PracticeDetailScreen extends StatelessWidget {
             ),
             elevation: 0,
           ),
-          onPressed: () => _onNextButtonPressed(context, practiceProvider),
+          onPressed: () => _showPracticeStartModeSheet(
+              context, themeProvider, practiceProvider),
           child: const StandardText(
             text: '복습하기',
             fontSize: 16,
@@ -447,8 +448,15 @@ class PracticeDetailScreen extends StatelessWidget {
   }
 
   void _onNextButtonPressed(
-      BuildContext context, ProblemPracticeProvider practiceProvider) {
+      BuildContext context, ProblemPracticeProvider practiceProvider,
+      {required bool shuffle}) {
     if (practiceProvider.currentProblems.isNotEmpty) {
+      if (shuffle) {
+        practiceProvider.shuffleCurrentProblems();
+      } else {
+        practiceProvider.useRegisteredProblemOrder();
+      }
+
       Navigator.push(
         context,
         MaterialPageRoute(
@@ -467,9 +475,121 @@ class PracticeDetailScreen extends StatelessWidget {
     }
   }
 
-  Future<void> _showDeletePracticeDialog(BuildContext context) async {
-    final themeProvider = Provider.of<ThemeHandler>(context, listen: false);
+  void _showPracticeStartModeSheet(BuildContext context,
+      ThemeHandler themeProvider, ProblemPracticeProvider practiceProvider) {
+    if (practiceProvider.currentProblems.isEmpty) {
+      SnackBarDialog.showSnackBar(
+        context: context,
+        message: '복습 세트가 비어있습니다!',
+        backgroundColor: Colors.red,
+      );
+      return;
+    }
 
+    final openTime = DateTime.now();
+    showModalBottomSheet(
+      backgroundColor: Colors.transparent,
+      context: context,
+      isDismissible: false,
+      builder: (sheetContext) {
+        return TapRegion(
+          onTapOutside: (_) {
+            if (DateTime.now().difference(openTime) <
+                const Duration(milliseconds: 500)) {
+              return;
+            }
+            if (Navigator.canPop(sheetContext)) {
+              Navigator.pop(sheetContext);
+            }
+          },
+          child: Container(
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(20),
+                topRight: Radius.circular(20),
+              ),
+            ),
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(vertical: 24.0, horizontal: 20.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 40,
+                    height: 4,
+                    margin: const EdgeInsets.only(bottom: 20),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[300],
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          color:
+                              themeProvider.primaryColor.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Icon(
+                          Icons.play_arrow,
+                          color: themeProvider.primaryColor,
+                          size: 22,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      const StandardText(
+                        text: '복습 방식 선택',
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.black87,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  _buildActionItem(
+                    icon: Icons.format_list_numbered,
+                    iconColor: themeProvider.primaryColor,
+                    title: '등록한 순서로 복습하기',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _onNextButtonPressed(
+                        context,
+                        practiceProvider,
+                        shuffle: false,
+                      );
+                    },
+                    themeProvider: themeProvider,
+                  ),
+                  const SizedBox(height: 12),
+                  _buildActionItem(
+                    icon: Icons.shuffle,
+                    iconColor: themeProvider.primaryColor,
+                    title: '셔플 모드로 복습하기',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _onNextButtonPressed(
+                        context,
+                        practiceProvider,
+                        shuffle: true,
+                      );
+                    },
+                    themeProvider: themeProvider,
+                  ),
+                  const SizedBox(height: 4),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showDeletePracticeDialog(BuildContext context) async {
     return showDialog(
       context: context,
       builder: (context) {

--- a/lib/Screen/PracticeNote/PracticeDetailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeDetailScreen.dart
@@ -136,7 +136,7 @@ class PracticeDetailScreen extends StatelessWidget {
                         ),
                         const SizedBox(width: 12),
                         const StandardText(
-                          text: '복습 노트 편집하기',
+                          text: '복습 세트 편집하기',
                           fontSize: 18,
                           fontWeight: FontWeight.w600,
                           color: Colors.black87,
@@ -148,7 +148,7 @@ class PracticeDetailScreen extends StatelessWidget {
                     _buildActionItem(
                       icon: Icons.edit,
                       iconColor: themeProvider.primaryColor,
-                      title: '복습 노트 편집하기',
+                      title: '복습 세트 편집하기',
                       onTap: () {
                         Navigator.pop(context);
                         Navigator.push(
@@ -167,7 +167,7 @@ class PracticeDetailScreen extends StatelessWidget {
                     _buildActionItem(
                       icon: Icons.delete_forever,
                       iconColor: Colors.red,
-                      title: '복습 노트 삭제하기',
+                      title: '복습 세트 삭제하기',
                       titleColor: Colors.red,
                       onTap: () {
                         Navigator.pop(context);
@@ -341,7 +341,7 @@ class PracticeDetailScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             const StandardText(
-              text: '복습노트가 비어있습니다.\n오답노트를 추가해 편리한 복습을 해보세요!',
+              text: '복습 세트가 비어있습니다.\n오답노트를 추가해 편리한 복습을 해보세요!',
               fontSize: 16,
               color: Colors.black87,
               textAlign: TextAlign.center,
@@ -461,7 +461,7 @@ class PracticeDetailScreen extends StatelessWidget {
     } else {
       SnackBarDialog.showSnackBar(
         context: context,
-        message: '복습 노트가 비어있습니다!',
+        message: '복습 세트가 비어있습니다!',
         backgroundColor: Colors.red,
       );
     }
@@ -500,7 +500,7 @@ class PracticeDetailScreen extends StatelessWidget {
                     ),
                     const SizedBox(width: 12),
                     const StandardText(
-                      text: '복습 노트 삭제',
+                      text: '복습 세트 삭제',
                       fontSize: 18,
                       fontWeight: FontWeight.w600,
                       color: Colors.black87,
@@ -510,7 +510,7 @@ class PracticeDetailScreen extends StatelessWidget {
                 const SizedBox(height: 20),
                 // 내용
                 const StandardText(
-                  text: '정말로 이 복습 노트를 삭제하시겠습니까?',
+                  text: '정말로 이 복습 세트를 삭제하시겠습니까?',
                   fontSize: 15,
                   color: Colors.black87,
                   textAlign: TextAlign.center,

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -500,7 +500,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
               ),
               const SizedBox(height: 40),
               const StandardText(
-                text: '작성한 오답노트로 복습 세트를\n 생성해 시험을 준비하세요!',
+                text: '복습 세트에 오답노트를 담아\n 편리하게 시험을 준비하세요!',
                 fontSize: 16,
                 color: Colors.black,
                 textAlign: TextAlign.center,

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -56,7 +56,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
     final themeProvider = Provider.of<ThemeHandler>(context);
     final practiceProvider = Provider.of<ProblemPracticeProvider>(context);
 
-    // 복습 노트 생성/수정 후 타임스탬프가 변경되면 자동 새로고침
+    // 복습 세트 생성/수정 후 타임스탬프가 변경되면 자동 새로고침
     if (practiceProvider.practiceRefreshTimestamp !=
             _lastPracticeRefreshTimestamp &&
         practiceProvider.practiceRefreshTimestamp > 0) {
@@ -102,7 +102,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                 materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 icon: const Icon(Icons.add, color: Colors.white),
                 label: const StandardText(
-                  text: '복습노트 추가',
+                  text: '복습 세트 추가',
                   fontSize: 15,
                   color: Colors.white,
                   fontWeight: FontWeight.w600,
@@ -202,7 +202,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                         ),
                         const SizedBox(width: 12),
                         StandardText(
-                          text: '복습 노트 편집하기',
+                          text: '복습 세트 편집하기',
                           fontSize: 18,
                           fontWeight: FontWeight.w600,
                           color: Colors.black87,
@@ -214,7 +214,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                     _buildActionItem(
                       icon: Icons.add,
                       iconColor: themeProvider.primaryColor,
-                      title: '복습 노트 생성하기',
+                      title: '복습 세트 생성하기',
                       onTap: () async {
                         Navigator.pop(context);
                         await _navigateToPracticeCreate();
@@ -224,7 +224,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                     _buildActionItem(
                       icon: Icons.delete_forever,
                       iconColor: Colors.red,
-                      title: '복습 노트 삭제하기',
+                      title: '복습 세트 삭제하기',
                       titleColor: Colors.red,
                       onTap: () {
                         Navigator.pop(context);
@@ -391,7 +391,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                     ),
                     const SizedBox(width: 12),
                     const StandardText(
-                      text: '복습 노트 삭제',
+                      text: '복습 세트 삭제',
                       fontSize: 18,
                       fontWeight: FontWeight.w600,
                       color: Colors.black87,
@@ -401,7 +401,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                 const SizedBox(height: 20),
                 // 내용
                 const StandardText(
-                  text: '정말로 이 복습 노트를 삭제하시겠습니까?',
+                  text: '정말로 이 복습 세트를 삭제하시겠습니까?',
                   fontSize: 15,
                   color: Colors.black87,
                   textAlign: TextAlign.center,
@@ -449,7 +449,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                           Future.delayed(Duration.zero, () {
                             SnackBarDialog.showSnackBar(
                               context: context,
-                              message: '복습 노트가 삭제되었습니다!',
+                              message: '복습 세트가 삭제되었습니다!',
                               backgroundColor: themeProvider.primaryColor,
                             );
                           });
@@ -500,7 +500,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
               ),
               const SizedBox(height: 40),
               const StandardText(
-                text: '작성한 오답노트로 복습 노트를\n 생성해 시험을 준비하세요!',
+                text: '작성한 오답노트로 복습 세트를\n 생성해 시험을 준비하세요!',
                 fontSize: 16,
                 color: Colors.black,
                 textAlign: TextAlign.center,
@@ -520,7 +520,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                   ),
                 ),
                 child: const StandardText(
-                  text: '복습 노트 추가하기',
+                  text: '복습 세트 추가하기',
                   fontSize: 16,
                   color: Colors.white,
                 ),
@@ -595,7 +595,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
   void _navigateToPracticeDetail(int practiceId) async {
     final practiceProvider =
         Provider.of<ProblemPracticeProvider>(context, listen: false);
-    LoadingDialog.show(context, '복습 노트 로딩 중...');
+    LoadingDialog.show(context, '복습 세트 로딩 중...');
 
     // 상세 정보 조회 및 이동
     await practiceProvider.fetchPracticeNote(practiceId);

--- a/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeTitleWriteScreen.dart
@@ -115,7 +115,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               .updatePractice(widget.practiceNoteUpdateModel!);
 
           if (!context.mounted) return;
-          _showSnackBar(context, themeProvider, '복습 노트가 수정되었습니다.',
+          _showSnackBar(context, themeProvider, '복습 세트가 수정되었습니다.',
               themeProvider.primaryColor);
 
           Navigator.pop(context);
@@ -143,7 +143,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
               .registerPractice(widget.practiceRegisterModel!);
 
           if (!context.mounted) return;
-          _showSnackBar(context, themeProvider, '복습 노트가 생성되었습니다.',
+          _showSnackBar(context, themeProvider, '복습 세트가 생성되었습니다.',
               themeProvider.primaryColor);
 
           Navigator.pop(context);
@@ -163,8 +163,8 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
             context,
             themeProvider,
             isUpdate
-                ? '복습 노트 수정에 실패했습니다. 잠시 후 다시 시도해주세요.'
-                : '복습 노트 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
+                ? '복습 세트 수정에 실패했습니다. 잠시 후 다시 시도해주세요.'
+                : '복습 세트 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
             Colors.red,
           );
         }
@@ -288,7 +288,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
     return AppBar(
       title: StandardText(
         text:
-            widget.practiceNoteUpdateModel == null ? "복습 노트 만들기" : "복습 노트 수정하기",
+            widget.practiceNoteUpdateModel == null ? "복습 세트 만들기" : "복습 세트 수정하기",
         fontSize: 18,
         color: themeProvider.primaryColor,
       ),
@@ -317,7 +317,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
   Widget _buildTitleText() {
     return StandardText(
       text: widget.practiceNoteUpdateModel == null
-          ? "복습 노트의 이름을 입력해주세요"
+          ? "복습 세트의 이름을 입력해주세요"
           : "수정할 이름을 입력해주세요",
       fontSize: 18,
       color: Colors.black,
@@ -345,7 +345,7 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
             ),
             const SizedBox(width: 8),
             const StandardText(
-              text: '복습 노트 제목',
+              text: '복습 세트 제목',
               fontSize: 16,
               fontWeight: FontWeight.w500,
               color: Colors.black87,
@@ -453,8 +453,8 @@ class _PracticeTitleWriteScreenState extends State<PracticeTitleWriteScreen> {
           ),
           child: StandardText(
             text: widget.practiceRegisterModel == null
-                ? "복습 노트 수정하기"
-                : "복습 노트 만들기",
+                ? "복습 세트 수정하기"
+                : "복습 세트 만들기",
             fontSize: 16,
             fontWeight: FontWeight.bold,
             color: Colors.white,

--- a/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
@@ -800,7 +800,11 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
           addProblemIdList: [problemId],
           removeProblemIdList: const [],
         );
-        await practiceProvider.updatePractice(updateModel);
+        await practiceProvider.updatePractice(
+          updateModel,
+          refreshAfterUpdate: false,
+          showErrorSnackBar: false,
+        );
       }
 
       if (!mounted) return;

--- a/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
@@ -3,6 +3,8 @@ import 'dart:developer';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
+import 'package:ono/Model/PracticeNote/PracticeNoteUpdateModel.dart';
+import 'package:ono/Module/Dialog/SnackBarDialog.dart';
 import 'package:ono/Provider/PracticeNoteProvider.dart';
 import 'package:ono/Screen/ProblemRegister/ProblemRegisterScreen.dart';
 import 'package:ono/Util/AppErrorReporter.dart';
@@ -387,7 +389,7 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
                           ),
                         ),
                         const SizedBox(width: 12),
-                        StandardText(
+                        const StandardText(
                           text: '오답노트 편집하기',
                           fontSize: 20,
                           fontWeight: FontWeight.w600,
@@ -417,6 +419,19 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
                             .then((_) {
                           _setProblemModel();
                         });
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    _buildActionItem(
+                      icon: Icons.playlist_add,
+                      iconColor: themeProvider.primaryColor,
+                      title: '복습 세트에 추가하기',
+                      onTap: () {
+                        FirebaseAnalytics.instance.logEvent(
+                            name: 'problem_add_to_practice_set_button_click');
+                        Navigator.pop(context);
+                        _showPracticeSetSelectionSheet(
+                            problemModel, themeProvider);
                       },
                     ),
                     const SizedBox(height: 12),
@@ -492,6 +507,321 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
         ),
       ),
     );
+  }
+
+  Future<void> _showPracticeSetSelectionSheet(
+      ProblemModel problemModel, ThemeHandler themeProvider) async {
+    final practiceProvider =
+        Provider.of<ProblemPracticeProvider>(context, listen: false);
+
+    LoadingDialog.show(context, '복습 세트 목록 불러오는 중...');
+
+    try {
+      await practiceProvider.fetchAllPracticeContents();
+    } catch (e) {
+      if (!mounted) return;
+      LoadingDialog.hide(context);
+      SnackBarDialog.showSnackBar(
+        context: context,
+        message: '복습 세트 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+        backgroundColor: Colors.red,
+      );
+      return;
+    }
+
+    if (!mounted) return;
+    LoadingDialog.hide(context);
+
+    final selectedPracticeIds = <int>{};
+    final openTime = DateTime.now();
+
+    showModalBottomSheet(
+      backgroundColor: Colors.transparent,
+      context: context,
+      isScrollControlled: true,
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            final practices = practiceProvider.practices;
+
+            return TapRegion(
+              onTapOutside: (_) {
+                if (DateTime.now().difference(openTime) <
+                    const Duration(milliseconds: 500)) {
+                  return;
+                }
+                if (Navigator.canPop(sheetContext)) {
+                  Navigator.pop(sheetContext);
+                }
+              },
+              child: Container(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(context).size.height * 0.78,
+                ),
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(20),
+                    topRight: Radius.circular(20),
+                  ),
+                ),
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: 20,
+                    right: 20,
+                    top: 24,
+                    bottom: MediaQuery.of(context).viewInsets.bottom + 20,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        width: 40,
+                        height: 4,
+                        margin: const EdgeInsets.only(bottom: 20),
+                        decoration: BoxDecoration(
+                          color: Colors.grey[300],
+                          borderRadius: BorderRadius.circular(2),
+                        ),
+                      ),
+                      Row(
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.all(8),
+                            decoration: BoxDecoration(
+                              color: themeProvider.primaryColor
+                                  .withValues(alpha: 0.1),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Icon(
+                              Icons.playlist_add,
+                              color: themeProvider.primaryColor,
+                              size: 22,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          const Expanded(
+                            child: StandardText(
+                              text: '복습 세트에 추가하기',
+                              fontSize: 20,
+                              fontWeight: FontWeight.w600,
+                              color: Colors.black87,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 20),
+                      if (practices.isEmpty)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 32),
+                          child: Column(
+                            children: [
+                              Icon(
+                                Icons.playlist_add_check,
+                                size: 44,
+                                color: Colors.grey[350],
+                              ),
+                              const SizedBox(height: 12),
+                              const StandardText(
+                                text: '아직 복습 세트가 없습니다.',
+                                fontSize: 16,
+                                color: Colors.black87,
+                              ),
+                            ],
+                          ),
+                        )
+                      else
+                        Flexible(
+                          child: ListView.separated(
+                            shrinkWrap: true,
+                            itemCount: practices.length,
+                            separatorBuilder: (_, __) =>
+                                const SizedBox(height: 10),
+                            itemBuilder: (context, index) {
+                              final practice = practices[index];
+                              final alreadyAdded = practice.problemIdList
+                                  .contains(problemModel.problemId);
+                              final selected = selectedPracticeIds
+                                  .contains(practice.practiceId);
+
+                              return InkWell(
+                                onTap: alreadyAdded
+                                    ? null
+                                    : () {
+                                        setSheetState(() {
+                                          if (selected) {
+                                            selectedPracticeIds
+                                                .remove(practice.practiceId);
+                                          } else {
+                                            selectedPracticeIds
+                                                .add(practice.practiceId);
+                                          }
+                                        });
+                                      },
+                                borderRadius: BorderRadius.circular(12),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 14, vertical: 12),
+                                  decoration: BoxDecoration(
+                                    color: alreadyAdded
+                                        ? Colors.grey[100]
+                                        : Colors.grey[50],
+                                    borderRadius: BorderRadius.circular(12),
+                                    border: Border.all(
+                                      color: selected
+                                          ? themeProvider.primaryColor
+                                          : Colors.grey[200]!,
+                                      width: selected ? 1.5 : 1,
+                                    ),
+                                  ),
+                                  child: Row(
+                                    children: [
+                                      Icon(
+                                        alreadyAdded
+                                            ? Icons.check_circle
+                                            : selected
+                                                ? Icons.check_circle
+                                                : Icons.radio_button_unchecked,
+                                        color: alreadyAdded
+                                            ? Colors.grey
+                                            : selected
+                                                ? themeProvider.primaryColor
+                                                : Colors.grey[400],
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            StandardText(
+                                              text: practice.practiceTitle,
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.w500,
+                                              color: alreadyAdded
+                                                  ? Colors.grey
+                                                  : Colors.black87,
+                                            ),
+                                            const SizedBox(height: 4),
+                                            StandardText(
+                                              text: alreadyAdded
+                                                  ? '이미 추가된 문제입니다'
+                                                  : '문제 ${practice.practiceSize}개',
+                                              fontSize: 13,
+                                              color: Colors.grey[600]!,
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      const SizedBox(height: 18),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextButton(
+                              onPressed: () => Navigator.pop(sheetContext),
+                              style: TextButton.styleFrom(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 13),
+                                backgroundColor: Colors.grey[100],
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                              ),
+                              child: const StandardText(
+                                text: '취소',
+                                fontSize: 15,
+                                color: Colors.black87,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: TextButton(
+                              onPressed: selectedPracticeIds.isEmpty
+                                  ? null
+                                  : () {
+                                      final targetPracticeIds =
+                                          selectedPracticeIds.toList();
+                                      Navigator.pop(sheetContext);
+                                      _addProblemToPracticeSets(
+                                        problemModel.problemId,
+                                        targetPracticeIds,
+                                        themeProvider,
+                                      );
+                                    },
+                              style: TextButton.styleFrom(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 13),
+                                backgroundColor: selectedPracticeIds.isEmpty
+                                    ? Colors.grey[300]
+                                    : themeProvider.primaryColor,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                              ),
+                              child: const StandardText(
+                                text: '추가',
+                                fontSize: 15,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _addProblemToPracticeSets(
+      int problemId, List<int> practiceIds, ThemeHandler themeProvider) async {
+    final practiceProvider =
+        Provider.of<ProblemPracticeProvider>(context, listen: false);
+
+    LoadingDialog.show(context, '복습 세트에 추가 중...');
+
+    try {
+      for (final practiceId in practiceIds) {
+        final updateModel = PracticeNoteUpdateModel(
+          practiceNoteId: practiceId,
+          addProblemIdList: [problemId],
+          removeProblemIdList: const [],
+        );
+        await practiceProvider.updatePractice(updateModel);
+      }
+
+      if (!mounted) return;
+      LoadingDialog.hide(context);
+      SnackBarDialog.showSnackBar(
+        context: context,
+        message: practiceIds.length == 1
+            ? '복습 세트에 추가되었습니다.'
+            : '${practiceIds.length}개의 복습 세트에 추가되었습니다.',
+        backgroundColor: themeProvider.primaryColor,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      LoadingDialog.hide(context);
+      SnackBarDialog.showSnackBar(
+        context: context,
+        message: '복습 세트에 추가하지 못했습니다. 잠시 후 다시 시도해주세요.',
+        backgroundColor: Colors.red,
+      );
+      log('복습 세트 문제 추가 실패: $e');
+    }
   }
 
   Future<void> _showDeleteProblemDialog(
@@ -574,9 +904,6 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
                           // context가 유효할 때 Provider와 Navigator 가져오기
                           final problemsProvider =
                               Provider.of<ProblemsProvider>(context,
-                                  listen: false);
-                          final practiceProvider =
-                              Provider.of<ProblemPracticeProvider>(context,
                                   listen: false);
                           final navigator = Navigator.of(context);
 

--- a/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
+++ b/lib/Screen/ProblemRegister/ProblemRegisterTemplate.dart
@@ -1053,19 +1053,37 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
       tagIds: _selectedTagIds.toList(),
     );
 
-    // 등록 후 분석 요청 비동기 실행
-    await problemService.requestProblemAnalysis(registeredProblemId);
+    // 등록 후 분석/캐시 갱신은 후처리이므로 실패해도 등록 성공을 막지 않습니다.
+    await _runPostSaveTask(
+      () => problemService.requestProblemAnalysis(
+        registeredProblemId,
+        showErrorSnackBar: false,
+      ),
+      source: 'problem_register_analysis_request',
+    );
 
     // Provider를 통해 문제 조회 및 상태 업데이트
-    await problemsProvider.fetchProblem(registeredProblemId);
+    await _runPostSaveTask(
+      () => problemsProvider.fetchProblem(
+        registeredProblemId,
+        showErrorSnackBar: false,
+      ),
+      source: 'problem_register_detail_refresh',
+    );
     await problemsProvider.updateProblemCount(1);
     if (!context.mounted) return;
     // requestReview may show a fallback dialog, so keep the mounted guard above.
     // ignore: use_build_context_synchronously
-    await problemsProvider.requestReview(context);
+    await _runPostSaveTask(
+      () => problemsProvider.requestReview(context),
+      source: 'problem_register_review_request',
+    );
 
     // 2. 유저 정보 갱신 (경험치 업데이트)
-    await userProvider.fetchUserInfo();
+    await _runPostSaveTask(
+      () => userProvider.fetchUserInfo(showErrorSnackBar: false),
+      source: 'problem_register_user_refresh',
+    );
 
     // 3. 폴더 갱신 (화면 전환 전에 먼저 캐시 삭제 및 타임스탬프 업데이트)
     if (_selectedFolderId != null) {
@@ -1180,6 +1198,25 @@ class ProblemRegisterTemplateState extends State<ProblemRegisterTemplate> {
     // 기존 폴더가 새 폴더와 다르면 기존 폴더도 갱신
     if (originalFolderId != null && originalFolderId != _selectedFolderId) {
       await foldersProvider.refreshFolder(originalFolderId);
+    }
+  }
+
+  Future<void> _runPostSaveTask(
+    Future<void> Function() task, {
+    required String source,
+  }) async {
+    try {
+      await task();
+    } catch (e, stackTrace) {
+      log('Post-save task failed ($source): $e');
+      unawaited(
+        AppErrorReporter.report(
+          e,
+          stackTrace,
+          source: source,
+          severity: AppErrorSeverity.warning,
+        ),
+      );
     }
   }
 

--- a/lib/Screen/ProblemSolve/ProblemSolveRegisterScreen.dart
+++ b/lib/Screen/ProblemSolve/ProblemSolveRegisterScreen.dart
@@ -154,7 +154,7 @@ class _ProblemSolveRegisterScreenState
       // 3. 문제 정보 갱신
       await problemsProvider.fetchProblem(widget.problemId);
 
-      // 4. 복습 노트 갱신
+      // 4. 복습 세트 갱신
       if (practiceProvider.currentPracticeNote != null) {
         await practiceProvider.moveToPractice(
           practiceProvider.currentPracticeNote!.practiceId,

--- a/lib/Screen/User/Widget/CompactActivityLevels.dart
+++ b/lib/Screen/User/Widget/CompactActivityLevels.dart
@@ -104,7 +104,7 @@ class CompactActivityLevels extends StatelessWidget {
           SizedBox(height: screenHeight * 0.017),
           _buildActivityRow(
             icon: Icons.history,
-            category: '복습노트 복습',
+            category: '복습 세트 복습',
             level: userInfo!.notePracticeLevel,
             point: userInfo!.notePracticePoint,
             color: Colors.blue[300]!,

--- a/lib/Screen/User/Widget/ReviewReportScreen.dart
+++ b/lib/Screen/User/Widget/ReviewReportScreen.dart
@@ -460,7 +460,7 @@ class _ReviewReportScreenState extends State<ReviewReportScreen> {
             Expanded(
               child: _buildStatCard(
                 themeProvider,
-                '복습노트 열람',
+                '복습 세트 열람',
                 '${data.notePracticeCount}회',
                 Icons.menu_book_rounded,
               ),

--- a/lib/Service/Api/Folder/FolderService.dart
+++ b/lib/Service/Api/Folder/FolderService.dart
@@ -10,10 +10,14 @@ class FolderService {
   final HttpService httpService = HttpService();
   final baseUrl = "${AppConfig.baseUrl}/api/folders";
 
-  Future<FolderModel> fetchFolder(int folderId) async {
+  Future<FolderModel> fetchFolder(
+    int folderId, {
+    bool showErrorSnackBar = true,
+  }) async {
     final data = await httpService.sendRequest(
       method: 'GET',
       url: '$baseUrl/$folderId',
+      showErrorSnackBar: showErrorSnackBar,
     );
 
     return FolderModel.fromJson(data);

--- a/lib/Service/Api/HttpService.dart
+++ b/lib/Service/Api/HttpService.dart
@@ -17,10 +17,7 @@ class HttpService {
 
   String _getErrorMessage(Object error) {
     if (error is UnauthorizedException) {
-      return ErrorMessageMapper.sanitizeRawMessage(
-        error.getUserMessage(),
-        fallback: ErrorMessages.authRequired,
-      );
+      return error.getUserMessage();
     }
     if (error is NetworkException) {
       return ErrorMessageMapper.sanitizeRawMessage(
@@ -285,9 +282,11 @@ class HttpService {
         rawMessage: serverMessage,
       );
 
-      // 토큰 만료 시 재시도 (status 401 또는 errorCode 1005)
+      // 토큰 만료 시 재시도 (ACCESS_TOKEN_EXPIRED 또는 코드 없는 401)
       // requiredToken이 true이고, 아직 재시도하지 않았다면 토큰 갱신 후 재시도
-      if (requiredToken && !retry && (status == 401 || errorCode == 1005)) {
+      final shouldRefreshToken =
+          errorCode == 1005 || (errorCode == null && status == 401);
+      if (requiredToken && !retry && shouldRefreshToken) {
         await tokenProvider.refreshAccessToken();
         return sendRequest(
           method: method,
@@ -306,10 +305,13 @@ class HttpService {
       // errorCode 기반으로 예외 타입 결정 (서버가 모든 에러를 400으로 통일)
       // errorCode가 있으면 우선적으로 errorCode로 판단
       if (errorCode != null) {
-        // 인증 관련 에러 코드 (예: 1004, 1005)
+        // 인증 관련 에러 코드
         if (errorCode >= 1000 && errorCode < 2000) {
           _throwWithSnackBar(
-            UnauthorizedException(message: message),
+            UnauthorizedException(
+              errorCode: errorCode,
+              message: message,
+            ),
             showErrorSnackBar: showErrorSnackBar,
           );
         }
@@ -327,7 +329,10 @@ class HttpService {
       // errorCode가 없을 경우 상태 코드로 판단
       if (status == 401) {
         _throwWithSnackBar(
-          UnauthorizedException(message: message),
+          UnauthorizedException(
+            errorCode: errorCode,
+            message: message,
+          ),
           showErrorSnackBar: showErrorSnackBar,
         );
       } else if (status >= 400 && status < 500) {

--- a/lib/Service/Api/PracticeNote/PracticeNoteService.dart
+++ b/lib/Service/Api/PracticeNote/PracticeNoteService.dart
@@ -59,11 +59,14 @@ class PracticeNoteService {
   }
 
   Future<void> updatePracticeNote(
-      PracticeNoteUpdateModel practiceNoteUpdateModel) async {
+    PracticeNoteUpdateModel practiceNoteUpdateModel, {
+    bool showErrorSnackBar = true,
+  }) async {
     await httpService.sendRequest(
       method: 'PATCH',
       url: '$baseUrl',
       body: practiceNoteUpdateModel.toJson(),
+      showErrorSnackBar: showErrorSnackBar,
     );
   }
 
@@ -83,7 +86,8 @@ class PracticeNoteService {
   }
 
   // V2 API - Cursor-based pagination for practice note thumbnails
-  Future<PaginatedResponse<PracticeNoteThumbnails>> getPracticeNoteThumbnailsV2({
+  Future<PaginatedResponse<PracticeNoteThumbnails>>
+      getPracticeNoteThumbnailsV2({
     int? cursor,
     int size = 20,
   }) async {

--- a/lib/Service/Api/PracticeNote/PracticeNoteService.dart
+++ b/lib/Service/Api/PracticeNote/PracticeNoteService.dart
@@ -11,10 +11,14 @@ class PracticeNoteService {
   final HttpService httpService = HttpService();
   final baseUrl = "${AppConfig.baseUrl}/api/practiceNotes";
 
-  Future<PracticeNoteDetailModel> getPracticeNoteById(int practiceId) async {
+  Future<PracticeNoteDetailModel> getPracticeNoteById(
+    int practiceId, {
+    bool showErrorSnackBar = true,
+  }) async {
     final data = await httpService.sendRequest(
       method: 'GET',
       url: '$baseUrl/$practiceId',
+      showErrorSnackBar: showErrorSnackBar,
     );
 
     return PracticeNoteDetailModel.fromJson(data);
@@ -60,7 +64,7 @@ class PracticeNoteService {
 
   Future<void> updatePracticeNote(
     PracticeNoteUpdateModel practiceNoteUpdateModel, {
-    bool showErrorSnackBar = true,
+    bool showErrorSnackBar = false,
   }) async {
     await httpService.sendRequest(
       method: 'PATCH',

--- a/lib/Service/Api/Problem/ProblemService.dart
+++ b/lib/Service/Api/Problem/ProblemService.dart
@@ -14,11 +14,15 @@ class ProblemService {
   final HttpService httpService = HttpService();
   final baseUrl = "${AppConfig.baseUrl}/api/problems";
 
-  Future<ProblemModel> getProblem(int? problemId) async {
+  Future<ProblemModel> getProblem(
+    int? problemId, {
+    bool showErrorSnackBar = true,
+  }) async {
     log('find problem id : $problemId');
     final data = await httpService.sendRequest(
       method: 'GET',
       url: '$baseUrl/$problemId',
+      showErrorSnackBar: showErrorSnackBar,
     );
 
     return ProblemModel.fromJson(data as Map<String, dynamic>);
@@ -35,10 +39,11 @@ class ProblemService {
         .toList();
   }
 
-  Future<int> getProblemCount() async {
+  Future<int> getProblemCount({bool showErrorSnackBar = true}) async {
     return await httpService.sendRequest(
       method: 'GET',
       url: '$baseUrl/problemCount',
+      showErrorSnackBar: showErrorSnackBar,
     ) as int;
   }
 
@@ -77,10 +82,14 @@ class ProblemService {
     ) as int;
   }
 
-  Future<void> requestProblemAnalysis(int problemId) async {
+  Future<void> requestProblemAnalysis(
+    int problemId, {
+    bool showErrorSnackBar = true,
+  }) async {
     await httpService.sendRequest(
       method: 'POST',
       url: '$baseUrl/$problemId/analysis',
+      showErrorSnackBar: showErrorSnackBar,
     );
   }
 

--- a/lib/Service/Api/User/UserService.dart
+++ b/lib/Service/Api/User/UserService.dart
@@ -29,10 +29,11 @@ class UserService {
     );
   }
 
-  Future<UserInfoModel> fetchUserInfo() async {
+  Future<UserInfoModel> fetchUserInfo({bool showErrorSnackBar = true}) async {
     final data = await httpService.sendRequest(
       method: 'GET',
       url: '${AppConfig.baseUrl}/api/users',
+      showErrorSnackBar: showErrorSnackBar,
     );
 
     return UserInfoModel.fromJson(data);

--- a/lib/Util/ErrorMessageMapper.dart
+++ b/lib/Util/ErrorMessageMapper.dart
@@ -4,15 +4,57 @@ class ErrorMessageMapper {
   static String byErrorCode({required int? errorCode, String? fallback}) {
     switch (errorCode) {
       case 1001:
-        return ErrorMessages.requestInvalid;
+        return ErrorMessages.invalidRefreshToken;
       case 1002:
-        return ErrorMessages.requiredFieldMissing;
+        return ErrorMessages.refreshTokenNotFound;
       case 1003:
-        return ErrorMessages.notFound;
+        return ErrorMessages.invalidAuthority;
       case 1004:
-        return ErrorMessages.forbidden;
+        return ErrorMessages.refreshTokenNotEqual;
       case 1005:
-        return ErrorMessages.sessionExpired;
+        return ErrorMessages.accessTokenExpired;
+      case 1006:
+        return ErrorMessages.refreshTokenExpired;
+      case 1007:
+        return ErrorMessages.authenticationFailed;
+      case 1008:
+        return ErrorMessages.accessDenied;
+      case 1009:
+        return ErrorMessages.invalidAccessToken;
+      case 2001:
+        return ErrorMessages.fileUploadFailed;
+      case 3001:
+        return ErrorMessages.userNotFound;
+      case 4001:
+        return ErrorMessages.problemNotFound;
+      case 4002:
+        return ErrorMessages.problemUserUnmatched;
+      case 4003:
+        return ErrorMessages.problemSolveImageAlreadyRegistered;
+      case 4004:
+        return ErrorMessages.problemAnalysisNotFound;
+      case 4021:
+        return ErrorMessages.problemSolveNotFound;
+      case 4022:
+        return ErrorMessages.problemSolveUserUnmatched;
+      case 5001:
+        return ErrorMessages.folderNotFound;
+      case 5002:
+        return ErrorMessages.folderUserUnmatched;
+      case 5003:
+        return ErrorMessages.rootFolderNotExist;
+      case 5004:
+        return ErrorMessages.rootFolderCannotRemove;
+      case 6001:
+        return ErrorMessages.practiceNoteNotFound;
+      case 7001:
+        return ErrorMessages.missionTypeNotFound;
+      case 7002:
+        return ErrorMessages.missionUserNotFound;
+      case 8001:
+        return ErrorMessages.fcmTokenNotFound;
+      case 8002:
+        return ErrorMessages.fcmSendFailed;
       case 9001:
         return ErrorMessages.tagNameEmpty;
       case 9002:
@@ -65,6 +107,7 @@ class ErrorMessageMapper {
     return lower.contains('unauthorizedexception') ||
         lower.contains('authorization token') ||
         lower.contains('refresh token') ||
+        lower.contains('리프레시토큰') ||
         lower.contains('로그인이 필요') ||
         lower.contains('세션이 만료');
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,17 +29,12 @@ import 'Util/AppErrorReporter.dart';
 import 'Util/NotificationService.dart';
 import 'Util/AppSnackBar.dart';
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await dotenv.load(fileName: '.env');
+Future<void> main() async {
+  await runZonedGuarded<Future<void>>(
+    () async {
+      WidgetsFlutterBinding.ensureInitialized();
+      await dotenv.load(fileName: '.env');
 
-  await SentryFlutter.init(
-    (options) {
-      options.dsn = dotenv.env['SENTRY_DSN'] ?? '';
-      options.profilesSampleRate = 0.0;
-      options.tracesSampleRate = 1.0;
-    },
-    appRunner: () {
       FlutterError.onError = (details) {
         FlutterError.presentError(details);
         unawaited(
@@ -64,16 +59,21 @@ void main() async {
         return true;
       };
 
-      runZonedGuarded<Future<void>>(
-        _bootstrapApp,
-        (error, stackTrace) async {
-          await AppErrorReporter.report(
-            error,
-            stackTrace,
-            source: 'zoned_guarded',
-            severity: AppErrorSeverity.fatal,
-          );
+      await SentryFlutter.init(
+        (options) {
+          options.dsn = dotenv.env['SENTRY_DSN'] ?? '';
+          options.profilesSampleRate = 0.0;
+          options.tracesSampleRate = 1.0;
         },
+        appRunner: _bootstrapApp,
+      );
+    },
+    (error, stackTrace) async {
+      await AppErrorReporter.report(
+        error,
+        stackTrace,
+        source: 'zoned_guarded',
+        severity: AppErrorSeverity.fatal,
       );
     },
   );


### PR DESCRIPTION
# PR 보고서

## PR Title

```text
feat: 복습 세트 UX 개선 및 후처리 오류 표시 방지
```

## PR Message

```markdown
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

> 복습노트 용어를 복습 세트로 통일하고, 오답노트 상세에서 복습 세트에 바로 추가할 수 있는 동선과 복습 시작 방식 선택 기능을 추가했습니다. 또한 생성/수정/삭제 API 성공 후 refresh 실패가 사용자에게 실패처럼 표시되지 않도록 후처리 오류 처리 범위를 조정했습니다.

- 서비스 내 `복습노트`, `복습 노트` 노출 문구를 `복습 세트`로 변경
- 오답노트 상세 옵션에 `복습 세트에 추가하기` 액션 추가
- 복습 세트 선택 바텀시트에서 여러 세트에 현재 문제를 한 번에 추가하도록 구현
- 이미 추가된 문제는 `이미 추가된 문제입니다`로 표시하고 중복 선택을 막도록 처리
- 복습 세트 상세의 `복습하기` 진입 시 등록 순서/셔플 모드 선택 바텀시트 추가
- 복습 진행 순서를 등록 순서로 복원하거나 현재 문제 목록을 셔플할 수 있도록 Provider 메서드 추가
- 생성/수정/삭제 성공 후 상세 조회, 카운트 조회, 유저 정보 갱신 등 후처리 refresh 실패가 원 작업 실패로 표시되지 않도록 분리
- 후처리 refresh 호출에만 `showErrorSnackBar: false`를 명시하고, 일반 HTTP 호출의 기본 에러 스낵바 동작은 유지
- 후처리 실패는 사용자 흐름을 막지 않고 warning으로 리포팅하도록 처리

### 스크린샷 (선택)

- UI 변경 사항은 앱 실행 후 아래 화면에서 확인이 필요합니다.
- 오답노트 상세 옵션 > 복습 세트에 추가하기
- 복습 세트 상세 > 복습하기 > 복습 방식 선택
```

## 변경 요약

- 최근 작업 기준 커밋 범위: `a74c39d..c9cf294`
- 주요 커밋:
  - `[chore] 복습 노트 -> 복습 세트 명칭 변경`
  - `[feat] 오답노트에서 복습 세트 바로 추가 기능 구현`
  - `[feat] 복습 세트 셔플 기능 구현`
  - `[fix] 정상 작동 시에 오류 메시지가 뜨는 문제 해결`
  - `[fix] 후처리 갱신 실패 시 성공 작업 오류 표시 방지`

## 주요 수정 파일

- `lib/Screen/ProblemDetail/ProblemDetailScreen.dart`
  - 오답노트 상세 옵션에 복습 세트 추가 동선 추가
  - 복습 세트 선택 바텀시트 및 중복 추가 방지 처리

- `lib/Screen/PracticeNote/PracticeDetailScreen.dart`
  - 복습 시작 전 등록 순서/셔플 모드 선택 UI 추가

- `lib/Provider/PracticeNoteProvider.dart`
  - 복습 문제 순서 복원 및 셔플 메서드 추가
  - 복습 세트 update 후 후처리 refresh 실패 처리 분리

- `lib/Provider/ProblemsProvider.dart`
  - 오답노트 생성/수정/삭제 후 조회/카운트 갱신 실패가 원 작업 실패로 전파되지 않도록 처리

- `lib/Provider/FoldersProvider.dart`
  - 폴더 생성/수정 후 메타데이터 refresh 실패 처리 분리

- `lib/Provider/UserProvider.dart`
  - 유저 정보 수정 후 정보 refresh 실패 처리 분리

- `lib/Service/Api/*Service.dart`
  - 후처리 refresh 경로에서만 공통 오류 스낵바를 끌 수 있도록 `showErrorSnackBar` 옵션 추가

- `README.md`, `lib/Constants/ErrorMessages.dart`, `lib/Screen/PracticeNote/*`, `lib/Screen/User/Widget/*`
  - 사용자 노출 용어를 복습 세트로 변경

## 검증

- `rg "복습\\s*노트|복습노트" README.md lib`
  - 잔여 노출 문구 없음 확인

- `dart format`
  - 변경 Dart 파일 포맷 완료

- 변경 파일 대상 `flutter analyze`
  - 새 컴파일 에러 없음
  - 기존 파일명 규칙, `withOpacity` deprecated, 일부 info 수준 lint는 기존 상태로 남아 있음

## 수동 확인 필요 항목

- 오답노트 상세 옵션에서 복습 세트 추가 성공/중복 추가 방지 여부
- 복습 세트 상세에서 등록 순서 복습과 셔플 모드 진입 여부
- 생성/수정/삭제 API가 정상 반영된 뒤 후처리 refresh 실패 상황에서 불필요한 `일시적인 오류` 스낵바가 뜨지 않는지
- 후처리 refresh 실패 후 목록/상세 화면이 오래된 캐시를 보여주는 경우 새로고침 동선이 자연스러운지
