### PR TITLE
 [Feat] 추천 복습 문제 기능 구현 및 오답노트 썸네일 복습 정보 UI 개선

### DIFF
--- a/lib/Model/Problem/ProblemModel.dart
+++ b/lib/Model/Problem/ProblemModel.dart
@@ -9,8 +9,10 @@ class ProblemModel {
   final String? memo;
   final String? reference;
   final DateTime? solvedAt;
+  final DateTime? lastSolvedAt;
   final DateTime? createdAt;
   final DateTime? updateAt;
+  final int solveCount;
 
   final List<ProblemImageDataModel>? problemImageDataList;
   final List<ProblemImageDataModel>? answerImageDataList;
@@ -26,8 +28,10 @@ class ProblemModel {
     this.memo,
     this.reference,
     this.solvedAt,
+    this.lastSolvedAt,
     this.createdAt,
     this.updateAt,
+    this.solveCount = 0,
     this.problemImageDataList,
     this.answerImageDataList,
     this.solveImageDataList,
@@ -73,12 +77,16 @@ class ProblemModel {
       solvedAt: json['solvedAt'] != null
           ? DateTime.parse(json['solvedAt'] as String)
           : null,
+      lastSolvedAt: json['lastSolvedAt'] != null
+          ? DateTime.parse(json['lastSolvedAt'] as String)
+          : null,
       createdAt: json['createdAt'] != null
           ? DateTime.parse(json['createdAt'] as String)
           : null,
       updateAt: json['updatedAt'] != null
           ? DateTime.parse(json['updatedAt'] as String)
           : null,
+      solveCount: (json['solveCount'] as num?)?.toInt() ?? 0,
       problemImageDataList: problemImages,
       answerImageDataList: answerImages,
       solveImageDataList: solveImages,
@@ -98,8 +106,10 @@ class ProblemModel {
       memo: memo,
       reference: reference,
       solvedAt: solvedAt,
+      lastSolvedAt: lastSolvedAt,
       createdAt: createdAt,
       updateAt: updateAt,
+      solveCount: solveCount,
       problemImageDataList: problemImageDataList,
       answerImageDataList: answerImageDataList,
       solveImageDataList: solveImageDataList,

--- a/lib/Model/Problem/ProblemThumbnailModel.dart
+++ b/lib/Model/Problem/ProblemThumbnailModel.dart
@@ -5,12 +5,16 @@ class ProblemThumbnailModel {
   final String? reference;
   final String? problemImageUrl;
   final DateTime? createdAt;
+  final DateTime? lastSolvedAt;
+  final int solveCount;
 
   ProblemThumbnailModel(
       {required this.problemId,
       required this.reference,
       required this.problemImageUrl,
-      required this.createdAt});
+      required this.createdAt,
+      this.lastSolvedAt,
+      this.solveCount = 0});
 
   factory ProblemThumbnailModel.fromJson(Map<String, dynamic> json) {
     return ProblemThumbnailModel(
@@ -18,6 +22,10 @@ class ProblemThumbnailModel {
       reference: json['reference'],
       problemImageUrl: json['problemImageUrl'],
       createdAt: json['createdAt'],
+      lastSolvedAt: json['lastSolvedAt'] != null
+          ? DateTime.parse(json['lastSolvedAt'] as String)
+          : null,
+      solveCount: (json['solveCount'] as num?)?.toInt() ?? 0,
     );
   }
 
@@ -29,6 +37,8 @@ class ProblemThumbnailModel {
           ? problemModel.problemImageDataList![0].imageUrl
           : null,
       createdAt: problemModel.createdAt,
+      lastSolvedAt: problemModel.lastSolvedAt,
+      solveCount: problemModel.solveCount,
     );
   }
 }

--- a/lib/Model/Problem/ReviewDueProblemModel.dart
+++ b/lib/Model/Problem/ReviewDueProblemModel.dart
@@ -1,0 +1,53 @@
+class ReviewDueProblemModel {
+  final int problemId;
+  final String? memo;
+  final String? reference;
+  final DateTime? nextReviewAt;
+  final int reviewInterval;
+  final int consecutiveCorrectCount;
+
+  ReviewDueProblemModel({
+    required this.problemId,
+    this.memo,
+    this.reference,
+    this.nextReviewAt,
+    required this.reviewInterval,
+    required this.consecutiveCorrectCount,
+  });
+
+  factory ReviewDueProblemModel.fromJson(Map<String, dynamic> json) {
+    return ReviewDueProblemModel(
+      problemId: json['problemId'] as int,
+      memo: json['memo'] as String?,
+      reference: json['reference'] as String?,
+      nextReviewAt: json['nextReviewAt'] != null
+          ? DateTime.tryParse(json['nextReviewAt'] as String)
+          : null,
+      reviewInterval: json['reviewInterval'] as int? ?? 1,
+      consecutiveCorrectCount: json['consecutiveCorrectCount'] as int? ?? 0,
+    );
+  }
+}
+
+class ReviewDueResponse {
+  final int dueCount;
+  final int overdueCount;
+  final List<ReviewDueProblemModel> problems;
+
+  ReviewDueResponse({
+    required this.dueCount,
+    required this.overdueCount,
+    required this.problems,
+  });
+
+  factory ReviewDueResponse.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>? ?? json;
+    return ReviewDueResponse(
+      dueCount: data['dueCount'] as int? ?? 0,
+      overdueCount: data['overdueCount'] as int? ?? 0,
+      problems: (data['problems'] as List<dynamic>? ?? [])
+          .map((e) => ReviewDueProblemModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}

--- a/lib/Model/User/UserInfoModel.dart
+++ b/lib/Model/User/UserInfoModel.dart
@@ -20,6 +20,8 @@ class UserInfoModel {
   int totalStudyCurrentPoint;
   int totalStudyNextLevelThreshold;
 
+  bool notificationEnabled;
+
   UserInfoModel({
     this.userId = -1,
     this.email = '',
@@ -37,6 +39,7 @@ class UserInfoModel {
     this.totalStudyLevel = 0,
     this.totalStudyCurrentPoint = 0,
     this.totalStudyNextLevelThreshold = 40,
+    this.notificationEnabled = true,
   });
 
   factory UserInfoModel.fromJson(dynamic json) {
@@ -61,6 +64,7 @@ class UserInfoModel {
       totalStudyLevel: json['totalStudyLevel'] ?? 0,
       totalStudyCurrentPoint: json['totalStudyCurrentPoint'] ?? 0,
       totalStudyNextLevelThreshold: json['totalStudyNextLevelThreshold'] ?? 40,
+      notificationEnabled: json['notificationEnabled'] ?? true,
     );
   }
 }

--- a/lib/Module/Problem/ProblemThumbnailCard.dart
+++ b/lib/Module/Problem/ProblemThumbnailCard.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../Model/Tag/TagModel.dart';
+import '../Image/DisplayImage.dart';
+import '../Text/StandardText.dart';
+import '../Theme/ThemeHandler.dart';
+
+class ProblemThumbnailCard extends StatelessWidget {
+  final String title;
+  final String? imageUrl;
+  final List<TagModel> tags;
+  final int solveCount;
+  final DateTime? lastSolvedAt;
+  final ThemeHandler themeProvider;
+  final bool isSelected;
+  final Widget? trailing;
+  final EdgeInsetsGeometry padding;
+
+  const ProblemThumbnailCard({
+    super.key,
+    required this.title,
+    required this.imageUrl,
+    required this.tags,
+    required this.solveCount,
+    required this.lastSolvedAt,
+    required this.themeProvider,
+    this.isSelected = false,
+    this.trailing,
+    this.padding = const EdgeInsets.all(12),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withValues(alpha: 0.2),
+            spreadRadius: 1,
+            blurRadius: 5,
+            offset: const Offset(0, 3),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          _buildImage(),
+          const SizedBox(width: 16),
+          Expanded(child: _buildTextColumn()),
+          const SizedBox(width: 12),
+          trailing ??
+              _buildSolveMeta(
+                solveCount,
+                lastSolvedAt,
+                themeProvider,
+              ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImage() {
+    return SizedBox(
+      width: 50,
+      height: 70,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: Colors.grey.shade300,
+            width: 0.8,
+          ),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: isSelected
+            ? Icon(Icons.check, color: themeProvider.primaryColor)
+            : DisplayImage(
+                imagePath: imageUrl,
+                fit: BoxFit.cover,
+              ),
+      ),
+    );
+  }
+
+  Widget _buildTextColumn() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 4),
+        StandardText(
+          text: title,
+          color: Colors.black,
+          fontSize: 16,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: tags.isNotEmpty
+              ? tags.map((tag) => _buildTag('#${tag.name}')).toList()
+              : [_buildEmptyTag()],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTag(String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: themeProvider.primaryColor,
+          width: 1,
+        ),
+      ),
+      child: StandardText(
+        text: text,
+        fontSize: 10,
+        color: themeProvider.primaryColor,
+      ),
+    );
+  }
+
+  Widget _buildEmptyTag() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: Colors.grey.shade300,
+          width: 1,
+        ),
+      ),
+      child: StandardText(
+        text: '태그 없음',
+        fontSize: 10,
+        color: Colors.grey.shade400,
+      ),
+    );
+  }
+
+  Widget _buildSolveMeta(
+    int solveCount,
+    DateTime? lastSolvedAt,
+    ThemeHandler themeProvider,
+  ) {
+    final cappedSolveCount = solveCount.clamp(0, 3);
+    final lastSolvedDateText =
+        lastSolvedAt != null ? DateFormat('M/d').format(lastSolvedAt) : null;
+
+    return Semantics(
+      label: lastSolvedDateText == null
+          ? '풀이 진행 $cappedSolveCount/3'
+          : '최근 복습 $lastSolvedDateText, 풀이 진행 $cappedSolveCount/3',
+      child: SizedBox(
+        width: 64,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade50,
+                borderRadius: BorderRadius.circular(7),
+                border: Border.all(color: Colors.grey.shade200),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(3, (index) {
+                  final filled = index < cappedSolveCount;
+                  return Container(
+                    width: 12,
+                    height: 4,
+                    margin: EdgeInsets.only(right: index == 2 ? 0 : 3),
+                    decoration: BoxDecoration(
+                      color: filled
+                          ? themeProvider.primaryColor
+                          : Colors.grey.shade300,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  );
+                }),
+              ),
+            ),
+            if (lastSolvedDateText != null) ...[
+              const SizedBox(height: 6),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                decoration: BoxDecoration(
+                  color: themeProvider.primaryColor.withValues(alpha: 0.07),
+                  borderRadius: BorderRadius.circular(7),
+                ),
+                child: Column(
+                  children: [
+                    StandardText(
+                      text: '최근 복습',
+                      fontSize: 10,
+                      color: themeProvider.primaryColor,
+                    ),
+                    const SizedBox(height: 1),
+                    StandardText(
+                      text: lastSolvedDateText,
+                      fontSize: 10,
+                      color: themeProvider.primaryColor,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Provider/ReviewDueProvider.dart
+++ b/lib/Provider/ReviewDueProvider.dart
@@ -1,0 +1,42 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:ono/Model/Problem/ReviewDueProblemModel.dart';
+import 'package:ono/Service/Api/Problem/ProblemService.dart';
+import 'package:ono/Util/AppErrorReporter.dart';
+
+class ReviewDueProvider with ChangeNotifier {
+  final ProblemService _problemService = ProblemService();
+
+  ReviewDueResponse? _data;
+  bool _isLoading = false;
+
+  ReviewDueResponse? get data => _data;
+  bool get isLoading => _isLoading;
+  int get dueCount => _data?.dueCount ?? 0;
+
+  Future<void> fetchReviewDue() async {
+    if (_isLoading) return;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      _data = await _problemService.getReviewDueProblems();
+    } catch (e, stackTrace) {
+      log('ReviewDueProvider fetchReviewDue error: $e');
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'review_due_fetch',
+        severity: AppErrorSeverity.warning,
+      );
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void clear() {
+    _data = null;
+    notifyListeners();
+  }
+}

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -255,6 +255,26 @@ class UserProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> updateNotificationSettings(bool enabled) async {
+    if (userInfoModel == null) return;
+    final previous = userInfoModel!.notificationEnabled;
+    userInfoModel!.notificationEnabled = enabled;
+    notifyListeners();
+    try {
+      await userService.updateNotificationSettings(enabled);
+    } catch (e, stackTrace) {
+      userInfoModel!.notificationEnabled = previous;
+      notifyListeners();
+      await AppErrorReporter.report(
+        e,
+        stackTrace,
+        source: 'notification_settings_update',
+        severity: AppErrorSeverity.warning,
+      );
+      rethrow;
+    }
+  }
+
   Future<void> updateUser({
     String? email,
     String? name,

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -23,11 +23,13 @@ import '../../Module/Image/DisplayImage.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Module/Util/FolderPickerDialog.dart';
+import '../../Provider/ReviewDueProvider.dart';
 import '../../Provider/UserProvider.dart';
 import '../../Util/AppErrorReporter.dart';
 import '../ProblemDetail/ProblemDetailScreen.dart';
 import '../ProblemRegister/ProblemRegisterScreen.dart';
 import '../ProblemSearch/TagProblemSearchScreen.dart';
+import '../ReviewDue/ReviewDueScreen.dart';
 import 'UserGuideScreen.dart';
 
 class DirectoryScreen extends StatefulWidget {
@@ -86,6 +88,10 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
 
       // 이 화면의 폴더 데이터 로드
       await _loadFolderData();
+
+      if (widget.folderId == null) {
+        Provider.of<ReviewDueProvider>(context, listen: false).fetchReviewDue();
+      }
 
       if (!modalShown && userProvider.isFirstLogin && widget.folderId == null) {
         modalShown = true;
@@ -517,6 +523,7 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     final authService = Provider.of<UserProvider>(context);
     final themeProvider = Provider.of<ThemeHandler>(context);
     final foldersProvider = Provider.of<FoldersProvider>(context);
+    final reviewDueProvider = Provider.of<ReviewDueProvider>(context);
 
     return PopScope(
         canPop: true,
@@ -533,6 +540,10 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
                     padding: const EdgeInsets.all(20),
                     child: Column(
                       children: [
+                        if (widget.folderId == null &&
+                            reviewDueProvider.dueCount > 0)
+                          _buildReviewDueBadge(
+                              context, reviewDueProvider, themeProvider),
                         _buildFolderAndProblemGrid(themeProvider),
                       ],
                     ),
@@ -2132,5 +2143,99 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
         await _loadFolderData();
       }
     });
+  }
+
+  Widget _buildReviewDueBadge(
+    BuildContext context,
+    ReviewDueProvider reviewDueProvider,
+    ThemeHandler themeProvider,
+  ) {
+    final data = reviewDueProvider.data;
+    final overdueCount = data?.overdueCount ?? 0;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: InkWell(
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const ReviewDueScreen()),
+          );
+        },
+        borderRadius: BorderRadius.circular(15),
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(15),
+            border: Border.all(color: Colors.grey[300]!, width: 1),
+            boxShadow: [
+              BoxShadow(
+                color: themeProvider.primaryColor.withValues(alpha: 0.1),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: themeProvider.primaryColor.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  Icons.auto_stories_outlined,
+                  color: themeProvider.primaryColor,
+                  size: 16,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const StandardText(
+                          text: '추천 복습 문제',
+                          fontSize: 14,
+                          color: Colors.black87,
+                        ),
+                        const SizedBox(width: 6),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 7, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: themeProvider.primaryColor,
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: StandardText(
+                            text: '${reviewDueProvider.dueCount}개',
+                            fontSize: 10,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (overdueCount > 0) ...[
+                      const SizedBox(height: 2),
+                      StandardText(
+                        text: '이 중 ${overdueCount}개는 밀린 문제예요',
+                        fontSize: 11,
+                        color: Colors.orange.shade600,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              Icon(Icons.chevron_right, size: 20, color: Colors.grey[400]),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -20,6 +20,7 @@ import '../../Model/Problem/ProblemThumbnailModel.dart';
 import '../../Exception/ApiException.dart';
 import '../../Module/Dialog/LoadingDialog.dart';
 import '../../Module/Image/DisplayImage.dart';
+import '../../Module/Problem/ProblemThumbnailCard.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Module/Util/FolderPickerDialog.dart';
@@ -1651,196 +1652,17 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
             problem.problemImageDataList!.isNotEmpty
         ? problem.problemImageDataList!.first.imageUrl
         : null;
+    final title =
+        problem.reference?.isNotEmpty == true ? problem.reference! : '제목 없음';
 
-    return Container(
-      padding: const EdgeInsets.all(12.0),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.grey.withOpacity(0.2),
-            spreadRadius: 1,
-            blurRadius: 5,
-            offset: const Offset(0, 3),
-          ),
-        ],
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          SizedBox(
-            width: 50,
-            height: 70,
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8.0),
-                border: Border.all(
-                  color: Colors.grey[300]!,
-                  width: 0.8,
-                ),
-              ),
-              clipBehavior: Clip.antiAlias,
-              child: isSelected
-                  ? Icon(Icons.check, color: themeProvider.primaryColor)
-                  : DisplayImage(
-                      imagePath: imageUrl,
-                      fit: BoxFit.cover,
-                    ),
-            ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const SizedBox(height: 4),
-                /*
-                _getTemplateIcon(problem.templateType!),
-                const SizedBox(width: 8),
-
-                 */
-                StandardText(
-                  text: (problem.reference != null &&
-                          problem.reference!.isNotEmpty)
-                      ? problem.reference!
-                      : '제목 없음',
-                  color: Colors.black,
-                  fontSize: 16,
-                ),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
-                  children: problem.tags.isNotEmpty
-                      ? problem.tags.map((tag) {
-                          return Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 3),
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(8),
-                              border: Border.all(
-                                color: themeProvider.primaryColor,
-                                width: 1,
-                              ),
-                            ),
-                            child: StandardText(
-                              text: '#${tag.name}',
-                              fontSize: 10,
-                              color: themeProvider.primaryColor,
-                            ),
-                          );
-                        }).toList()
-                      : [
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 3),
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(8),
-                              border: Border.all(
-                                color: Colors.grey[300]!,
-                                width: 1,
-                              ),
-                            ),
-                            child: StandardText(
-                              text: '태그 없음',
-                              fontSize: 10,
-                              color: Colors.grey[400]!,
-                            ),
-                          ),
-                        ],
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 12),
-          _buildProblemSolveMeta(
-            problem.solveCount,
-            problem.lastSolvedAt,
-            themeProvider,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildProblemSolveMeta(
-    int solveCount,
-    DateTime? lastSolvedAt,
-    ThemeHandler themeProvider,
-  ) {
-    final cappedSolveCount = solveCount.clamp(0, 3);
-    final lastSolvedDateText =
-        lastSolvedAt != null ? DateFormat('M/d').format(lastSolvedAt) : null;
-
-    return Semantics(
-      label: lastSolvedDateText == null
-          ? '풀이 진행 $cappedSolveCount/3'
-          : '최근 복습 $lastSolvedDateText, 풀이 진행 $cappedSolveCount/3',
-      child: SizedBox(
-        width: 64,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade50,
-                borderRadius: BorderRadius.circular(7),
-                border: Border.all(color: Colors.grey.shade200),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: List.generate(3, (index) {
-                  final filled = index < cappedSolveCount;
-                  return Container(
-                    width: 12,
-                    height: 4,
-                    margin: EdgeInsets.only(right: index == 2 ? 0 : 3),
-                    decoration: BoxDecoration(
-                      color: filled
-                          ? themeProvider.primaryColor
-                          : Colors.grey.shade300,
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                  );
-                }),
-              ),
-            ),
-            if (lastSolvedDateText != null) ...[
-              const SizedBox(height: 6),
-              Container(
-                width: double.infinity,
-                padding: const EdgeInsets.symmetric(vertical: 4),
-                decoration: BoxDecoration(
-                  color: themeProvider.primaryColor.withValues(alpha: 0.07),
-                  borderRadius: BorderRadius.circular(7),
-                ),
-                child: Column(
-                  children: [
-                    StandardText(
-                      text: '최근 복습',
-                      fontSize: 10,
-                      color: themeProvider.primaryColor,
-                    ),
-                    const SizedBox(height: 1),
-                    StandardText(
-                      text: lastSolvedDateText,
-                      fontSize: 10,
-                      color: themeProvider.primaryColor,
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
+    return ProblemThumbnailCard(
+      title: title,
+      imageUrl: imageUrl,
+      tags: problem.tags,
+      solveCount: problem.solveCount,
+      lastSolvedAt: problem.lastSolvedAt,
+      themeProvider: themeProvider,
+      isSelected: isSelected,
     );
   }
 

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -1689,34 +1689,27 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
                     ),
             ),
           ),
-          const SizedBox(width: 20),
+          const SizedBox(width: 16),
           Expanded(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const SizedBox(height: 4),
-                Row(
-                  children: [
-                    /*
-                    _getTemplateIcon(problem.templateType!),
-                    const SizedBox(width: 8),
+                /*
+                _getTemplateIcon(problem.templateType!),
+                const SizedBox(width: 8),
 
-                     */
-                    Flexible(
-                      child: StandardText(
-                        text: (problem.reference != null &&
-                                problem.reference!.isNotEmpty)
-                            ? problem.reference!
-                            : '제목 없음',
-                        color: Colors.black,
-                        fontSize: 18,
-                      ),
-                    ),
-                  ],
+                 */
+                StandardText(
+                  text: (problem.reference != null &&
+                          problem.reference!.isNotEmpty)
+                      ? problem.reference!
+                      : '제목 없음',
+                  color: Colors.black,
+                  fontSize: 16,
                 ),
-                const SizedBox(height: 2),
-                const SizedBox(height: 4),
+                const SizedBox(height: 8),
                 Wrap(
                   spacing: 6,
                   runSpacing: 6,
@@ -1735,7 +1728,7 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
                             ),
                             child: StandardText(
                               text: '#${tag.name}',
-                              fontSize: 11,
+                              fontSize: 10,
                               color: themeProvider.primaryColor,
                             ),
                           );
@@ -1754,7 +1747,7 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
                             ),
                             child: StandardText(
                               text: '태그 없음',
-                              fontSize: 11,
+                              fontSize: 10,
                               color: Colors.grey[400]!,
                             ),
                           ),
@@ -1763,7 +1756,90 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
               ],
             ),
           ),
+          const SizedBox(width: 12),
+          _buildProblemSolveMeta(
+            problem.solveCount,
+            problem.lastSolvedAt,
+            themeProvider,
+          ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildProblemSolveMeta(
+    int solveCount,
+    DateTime? lastSolvedAt,
+    ThemeHandler themeProvider,
+  ) {
+    final cappedSolveCount = solveCount.clamp(0, 3);
+    final lastSolvedDateText =
+        lastSolvedAt != null ? DateFormat('M/d').format(lastSolvedAt) : null;
+
+    return Semantics(
+      label: lastSolvedDateText == null
+          ? '풀이 진행 $cappedSolveCount/3'
+          : '최근 복습 $lastSolvedDateText, 풀이 진행 $cappedSolveCount/3',
+      child: SizedBox(
+        width: 64,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade50,
+                borderRadius: BorderRadius.circular(7),
+                border: Border.all(color: Colors.grey.shade200),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(3, (index) {
+                  final filled = index < cappedSolveCount;
+                  return Container(
+                    width: 12,
+                    height: 4,
+                    margin: EdgeInsets.only(right: index == 2 ? 0 : 3),
+                    decoration: BoxDecoration(
+                      color: filled
+                          ? themeProvider.primaryColor
+                          : Colors.grey.shade300,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  );
+                }),
+              ),
+            ),
+            if (lastSolvedDateText != null) ...[
+              const SizedBox(height: 6),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                decoration: BoxDecoration(
+                  color: themeProvider.primaryColor.withValues(alpha: 0.07),
+                  borderRadius: BorderRadius.circular(7),
+                ),
+                child: Column(
+                  children: [
+                    StandardText(
+                      text: '최근 복습',
+                      fontSize: 10,
+                      color: themeProvider.primaryColor,
+                    ),
+                    const SizedBox(height: 1),
+                    StandardText(
+                      text: lastSolvedDateText,
+                      fontSize: 10,
+                      color: themeProvider.primaryColor,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/Screen/PracticeNote/PracticeDetailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeDetailScreen.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import '../../Model/PracticeNote/PracticeNoteDetailModel.dart';
 import '../../Model/Problem/ProblemModel.dart';
 import '../../Module/Dialog/SnackBarDialog.dart';
-import '../../Module/Image/DisplayImage.dart';
+import '../../Module/Problem/ProblemThumbnailCard.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/PracticeNoteProvider.dart';
@@ -297,31 +297,18 @@ class PracticeDetailScreen extends StatelessWidget {
             problem.problemImageDataList!.isNotEmpty
         ? problem.problemImageDataList!.first.imageUrl
         : null;
+    final title =
+        problem.reference?.isNotEmpty == true ? problem.reference! : '제목 없음';
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Container(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.grey.withOpacity(0.2),
-              spreadRadius: 1,
-              blurRadius: 5,
-              offset: const Offset(0, 3),
-            ),
-          ],
-        ),
-        padding: const EdgeInsets.all(12),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            _buildImageThumbnail(imageUrl),
-            const SizedBox(width: 16),
-            _buildProblemDetails(problem),
-          ],
-        ),
+      child: ProblemThumbnailCard(
+        title: title,
+        imageUrl: imageUrl,
+        tags: problem.tags,
+        solveCount: problem.solveCount,
+        lastSolvedAt: problem.lastSolvedAt,
+        themeProvider: themeProvider,
       ),
     );
   }
@@ -376,44 +363,6 @@ class PracticeDetailScreen extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildImageThumbnail(String? imageUrl) {
-    return SizedBox(
-      width: 50,
-      height: 70,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(8.0),
-        child: DisplayImage(
-          imagePath: imageUrl,
-          fit: BoxFit.cover,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildProblemDetails(ProblemModel problem) {
-    return Expanded(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          StandardText(
-            text: (problem.reference != null && problem.reference!.isNotEmpty)
-                ? problem.reference!
-                : '제목 없음',
-            fontSize: 16,
-            color: Colors.black,
-          ),
-          const SizedBox(height: 4),
-          StandardText(
-            text:
-                '작성 일시: ${problem.createdAt != null ? formatDateTime(problem.createdAt!) : '정보 없음'}',
-            fontSize: 12,
-            color: Colors.grey,
-          ),
-        ],
       ),
     );
   }

--- a/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
@@ -13,8 +13,7 @@ import '../../Model/Folder/FolderThumbnailModel.dart';
 import '../../Model/PracticeNote/PracticeNoteRegisterModel.dart';
 import '../../Model/PracticeNote/PracticeNoteUpdateModel.dart';
 import '../../Model/Problem/ProblemModel.dart';
-import '../../Model/Problem/TemplateType.dart';
-import '../../Module/Image/DisplayImage.dart';
+import '../../Module/Problem/ProblemThumbnailCard.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/NoteIconHandler.dart';
 import '../../Module/Theme/ThemeHandler.dart';
@@ -927,68 +926,23 @@ class _PracticeProblemSelectionScreenState
             problem.problemImageDataList!.isNotEmpty
         ? problem.problemImageDataList!.first.imageUrl
         : null;
+    final title =
+        problem.reference?.isNotEmpty == true ? problem.reference! : '제목 없음';
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          SizedBox(
-            width: 50,
-            height: 70,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(8.0),
-              child: DisplayImage(
-                imagePath: problemImageUrl,
-                fit: BoxFit.cover,
-              ),
-            ),
-          ),
-          const SizedBox(width: 20),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    //_getTemplateIcon(problem.templateType!),
-                    //const SizedBox(width: 8),
-                    Flexible(
-                      child: StandardText(
-                        text: problem.reference?.isNotEmpty == true
-                            ? problem.reference!
-                            : '제목 없음',
-                        color: themeProvider.primaryColor,
-                        fontSize: 18,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 4),
-                StandardText(
-                  text: problem.createdAt != null
-                      ? '작성 일시: ${formatDateTime(problem.createdAt!)}'
-                      : '작성 일시: 정보 없음',
-                  fontSize: 12,
-                  color: themeProvider.desaturateColor,
-                ),
-              ],
-            ),
-          ),
-          isSelected
-              ? Icon(Icons.check_circle,
-                  color: themeProvider.primaryColor, size: 25)
-              : const Icon(Icons.circle_outlined, color: Colors.grey),
-        ],
+      child: ProblemThumbnailCard(
+        title: title,
+        imageUrl: problemImageUrl,
+        tags: problem.tags,
+        solveCount: problem.solveCount,
+        lastSolvedAt: problem.lastSolvedAt,
+        themeProvider: themeProvider,
+        trailing: isSelected
+            ? Icon(Icons.check_circle,
+                color: themeProvider.primaryColor, size: 25)
+            : const Icon(Icons.circle_outlined, color: Colors.grey),
       ),
-    );
-  }
-
-  Widget _getTemplateIcon(TemplateType templateType) {
-    return SvgPicture.asset(
-      templateType.templateThumbnailImage,
-      width: 20,
-      height: 20,
     );
   }
 
@@ -1000,92 +954,92 @@ class _PracticeProblemSelectionScreenState
         width: double.infinity,
         height: 50,
         child: ElevatedButton(
-        onPressed: selectedProblems.isNotEmpty
-            ? () {
-                final newIds =
-                    selectedProblems.map((p) => p.problemId).toList();
+          onPressed: selectedProblems.isNotEmpty
+              ? () {
+                  final newIds =
+                      selectedProblems.map((p) => p.problemId).toList();
 
-                // 추가된 문제: newIds 에는 있지만 원본에는 없는 것
-                final addList = newIds
-                    .where((id) => !_originalProblemIds.contains(id))
-                    .toList();
-                // 삭제된 문제: 원본에는 있고 newIds에는 없는 것
-                final removeList = _originalProblemIds
-                    .where((id) => !newIds.contains(id))
-                    .toList();
+                  // 추가된 문제: newIds 에는 있지만 원본에는 없는 것
+                  final addList = newIds
+                      .where((id) => !_originalProblemIds.contains(id))
+                      .toList();
+                  // 삭제된 문제: 원본에는 있고 newIds에는 없는 것
+                  final removeList = _originalProblemIds
+                      .where((id) => !newIds.contains(id))
+                      .toList();
 
-                if (widget.practiceModel != null) {
-                  // 수정 모드
-                  final updateModel = PracticeNoteUpdateModel(
-                    practiceNoteId: widget.practiceModel!.practiceId,
-                    practiceTitle: widget.practiceModel!.practiceTitle,
-                    addProblemIdList: addList,
-                    removeProblemIdList: removeList,
-                  );
-                  // 다음 화면으로 updateModel 넘기기
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => PracticeTitleWriteScreen(
-                        practiceNoteUpdateModel: updateModel,
-                        practiceNoteDetailModel: widget.practiceModel!,
+                  if (widget.practiceModel != null) {
+                    // 수정 모드
+                    final updateModel = PracticeNoteUpdateModel(
+                      practiceNoteId: widget.practiceModel!.practiceId,
+                      practiceTitle: widget.practiceModel!.practiceTitle,
+                      addProblemIdList: addList,
+                      removeProblemIdList: removeList,
+                    );
+                    // 다음 화면으로 updateModel 넘기기
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => PracticeTitleWriteScreen(
+                          practiceNoteUpdateModel: updateModel,
+                          practiceNoteDetailModel: widget.practiceModel!,
+                        ),
                       ),
-                    ),
-                  );
-                } else {
-                  // 신규 등록 모드 → 기존대로 RegisterModel
-                  final registerModel = PracticeNoteRegisterModel(
-                    practiceId: null,
-                    practiceTitle: "",
-                    registerProblemIdList: newIds,
-                  );
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => PracticeTitleWriteScreen(
-                        practiceRegisterModel: registerModel,
+                    );
+                  } else {
+                    // 신규 등록 모드 → 기존대로 RegisterModel
+                    final registerModel = PracticeNoteRegisterModel(
+                      practiceId: null,
+                      practiceTitle: "",
+                      registerProblemIdList: newIds,
+                    );
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => PracticeTitleWriteScreen(
+                          practiceRegisterModel: registerModel,
+                        ),
                       ),
-                    ),
-                  );
+                    );
+                  }
                 }
-              }
-            : () => _showSelectProblemDialog(context),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: themeProvider.primaryColor,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+              : () => _showSelectProblemDialog(context),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: themeProvider.primaryColor,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
+            elevation: 0,
           ),
-          elevation: 0,
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Expanded(
-              child: Center(
-                child: StandardText(
-                  text: "다음",
-                  fontSize: 16,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Expanded(
+                child: Center(
+                  child: StandardText(
+                    text: "다음",
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
                 ),
               ),
-            ),
-            Container(
-              width: 24,
-              height: 24,
-              alignment: Alignment.center,
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                shape: BoxShape.circle,
+              Container(
+                width: 24,
+                height: 24,
+                alignment: Alignment.center,
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  shape: BoxShape.circle,
+                ),
+                child: StandardText(
+                  text: selectedProblems.length.toString(),
+                  fontSize: 12,
+                  color: themeProvider.primaryColor,
+                ),
               ),
-              child: StandardText(
-                text: selectedProblems.length.toString(),
-                fontSize: 12,
-                color: themeProvider.primaryColor,
-              ),
-            ),
-          ],
-        ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 import 'package:ono/Module/Dialog/LoadingDialog.dart';
-import 'package:ono/Module/Dialog/SnackBarDialog.dart';
 import 'package:provider/provider.dart';
 
 import '../../Model/PracticeNote/PracticeNoteThumbnailModel.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/PracticeNoteProvider.dart';
+import '../../Util/AppSnackBar.dart';
 import 'PracticeDetailScreen.dart';
 import 'PracticeProblemSelectionScreen.dart';
 
@@ -446,13 +446,17 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
                             _selectedPracticeIds.clear();
                           });
 
-                          Future.delayed(Duration.zero, () {
-                            SnackBarDialog.showSnackBar(
-                              context: context,
-                              message: '복습 세트가 삭제되었습니다!',
+                          AppSnackBar.messengerKey.currentState?.showSnackBar(
+                            SnackBar(
+                              content: const StandardText(
+                                text: '복습 세트가 삭제되었습니다!',
+                                fontSize: 14,
+                                color: Colors.white,
+                              ),
                               backgroundColor: themeProvider.primaryColor,
-                            );
-                          });
+                              duration: const Duration(seconds: 2),
+                            ),
+                          );
                         },
                         style: TextButton.styleFrom(
                           padding: const EdgeInsets.symmetric(

--- a/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
+++ b/lib/Screen/ProblemDetail/ProblemDetailScreen.dart
@@ -643,6 +643,22 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
                                   .contains(problemModel.problemId);
                               final selected = selectedPracticeIds
                                   .contains(practice.practiceId);
+                              final itemColor = alreadyAdded
+                                  ? Colors.green.shade600
+                                  : selected
+                                      ? themeProvider.primaryColor
+                                      : Colors.grey.shade500;
+                              final itemBackgroundColor = alreadyAdded
+                                  ? Colors.green.withValues(alpha: 0.08)
+                                  : selected
+                                      ? themeProvider.primaryColor
+                                          .withValues(alpha: 0.08)
+                                      : Colors.white;
+                              final itemBorderColor = alreadyAdded
+                                  ? Colors.green.withValues(alpha: 0.28)
+                                  : selected
+                                      ? themeProvider.primaryColor
+                                      : Colors.grey.shade200;
 
                               return InkWell(
                                 onTap: alreadyAdded
@@ -663,30 +679,33 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
                                   padding: const EdgeInsets.symmetric(
                                       horizontal: 14, vertical: 12),
                                   decoration: BoxDecoration(
-                                    color: alreadyAdded
-                                        ? Colors.grey[100]
-                                        : Colors.grey[50],
+                                    color: itemBackgroundColor,
                                     borderRadius: BorderRadius.circular(12),
                                     border: Border.all(
-                                      color: selected
-                                          ? themeProvider.primaryColor
-                                          : Colors.grey[200]!,
-                                      width: selected ? 1.5 : 1,
+                                      color: itemBorderColor,
+                                      width: selected || alreadyAdded ? 1.5 : 1,
                                     ),
                                   ),
                                   child: Row(
                                     children: [
-                                      Icon(
-                                        alreadyAdded
-                                            ? Icons.check_circle
-                                            : selected
-                                                ? Icons.check_circle
-                                                : Icons.radio_button_unchecked,
-                                        color: alreadyAdded
-                                            ? Colors.grey
-                                            : selected
-                                                ? themeProvider.primaryColor
-                                                : Colors.grey[400],
+                                      Container(
+                                        width: 34,
+                                        height: 34,
+                                        decoration: BoxDecoration(
+                                          color:
+                                              itemColor.withValues(alpha: 0.12),
+                                          borderRadius:
+                                              BorderRadius.circular(10),
+                                        ),
+                                        child: Icon(
+                                          alreadyAdded
+                                              ? Icons.playlist_add_check
+                                              : selected
+                                                  ? Icons.check
+                                                  : Icons.add,
+                                          color: itemColor,
+                                          size: 20,
+                                        ),
                                       ),
                                       const SizedBox(width: 12),
                                       Expanded(
@@ -698,17 +717,20 @@ class _ProblemDetailScreenState extends State<ProblemDetailScreen> {
                                               text: practice.practiceTitle,
                                               fontSize: 16,
                                               fontWeight: FontWeight.w500,
-                                              color: alreadyAdded
-                                                  ? Colors.grey
-                                                  : Colors.black87,
+                                              color: Colors.black87,
                                             ),
                                             const SizedBox(height: 4),
                                             StandardText(
                                               text: alreadyAdded
-                                                  ? '이미 추가된 문제입니다'
+                                                  ? '이미 세트에 포함했습니다.'
                                                   : '문제 ${practice.practiceSize}개',
                                               fontSize: 13,
-                                              color: Colors.grey[600]!,
+                                              color: alreadyAdded
+                                                  ? Colors.green.shade700
+                                                  : selected
+                                                      ? themeProvider
+                                                          .primaryColor
+                                                      : Colors.grey[600]!,
                                             ),
                                           ],
                                         ),

--- a/lib/Screen/ProblemSearch/TagProblemSearchScreen.dart
+++ b/lib/Screen/ProblemSearch/TagProblemSearchScreen.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 
 import '../../Model/Problem/ProblemModel.dart';
 import '../../Model/Tag/TagModel.dart';
-import '../../Module/Image/DisplayImage.dart';
+import '../../Module/Problem/ProblemThumbnailCard.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/ProblemsProvider.dart';
@@ -525,6 +525,8 @@ class _TagProblemSearchScreenState extends State<TagProblemSearchScreen> {
         ? problem.problemImageDataList!.first.imageUrl
         : null;
     final isSelected = _isSelected(problem);
+    final title =
+        problem.reference?.isNotEmpty == true ? problem.reference! : '제목 없음';
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -541,115 +543,22 @@ class _TagProblemSearchScreenState extends State<TagProblemSearchScreen> {
             ),
           );
         },
-        child: Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(12),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.grey.withOpacity(0.2),
-                spreadRadius: 1,
-                blurRadius: 5,
-                offset: const Offset(0, 3),
-              ),
-            ],
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              SizedBox(
-                width: 50,
-                height: 70,
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: Colors.grey[300]!,
-                      width: 0.8,
-                    ),
-                  ),
-                  clipBehavior: Clip.antiAlias,
-                  child: DisplayImage(
-                    imagePath: problemImageUrl,
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    StandardText(
-                      text: (problem.reference != null &&
-                              problem.reference!.isNotEmpty)
-                          ? problem.reference!
-                          : '제목 없음',
-                      color: Colors.black,
-                      fontSize: 17,
-                    ),
-                    const SizedBox(height: 6),
-                    Wrap(
-                      spacing: 6,
-                      runSpacing: 6,
-                      children: problem.tags.isNotEmpty
-                          ? problem.tags.map((tag) {
-                              return Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 3,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: Colors.white,
-                                  borderRadius: BorderRadius.circular(8),
-                                  border: Border.all(
-                                    color: themeProvider.primaryColor,
-                                    width: 1,
-                                  ),
-                                ),
-                                child: StandardText(
-                                  text: '#${tag.name}',
-                                  fontSize: 11,
-                                  color: themeProvider.primaryColor,
-                                ),
-                              );
-                            }).toList()
-                          : [
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 3,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: Colors.white,
-                                  borderRadius: BorderRadius.circular(8),
-                                  border: Border.all(
-                                    color: Colors.grey[300]!,
-                                    width: 1,
-                                  ),
-                                ),
-                                child: StandardText(
-                                  text: '태그 없음',
-                                  fontSize: 11,
-                                  color: Colors.grey[400]!,
-                                ),
-                              ),
-                            ],
-                    ),
-                  ],
-                ),
-              ),
-              if (widget.selectable)
-                Icon(
+        child: ProblemThumbnailCard(
+          title: title,
+          imageUrl: problemImageUrl,
+          tags: problem.tags,
+          solveCount: problem.solveCount,
+          lastSolvedAt: problem.lastSolvedAt,
+          themeProvider: themeProvider,
+          trailing: widget.selectable
+              ? Icon(
                   isSelected ? Icons.check_circle : Icons.circle_outlined,
                   color: isSelected
                       ? themeProvider.primaryColor
                       : Colors.grey[400],
                   size: 22,
-                ),
-            ],
-          ),
+                )
+              : null,
         ),
       ),
     );

--- a/lib/Screen/ReviewDue/ReviewDueScreen.dart
+++ b/lib/Screen/ReviewDue/ReviewDueScreen.dart
@@ -1,0 +1,331 @@
+import 'package:flutter/material.dart';
+import 'package:ono/Model/Problem/ReviewDueProblemModel.dart';
+import 'package:ono/Module/Image/DisplayImage.dart';
+import 'package:ono/Module/Text/StandardText.dart';
+import 'package:ono/Module/Theme/ThemeHandler.dart';
+import 'package:ono/Provider/ReviewDueProvider.dart';
+import 'package:ono/Screen/ProblemDetail/ProblemDetailScreen.dart';
+import 'package:ono/Service/Api/Problem/ProblemService.dart';
+import 'package:provider/provider.dart';
+
+class ReviewDueScreen extends StatefulWidget {
+  const ReviewDueScreen({super.key});
+
+  @override
+  State<ReviewDueScreen> createState() => _ReviewDueScreenState();
+}
+
+class _ReviewDueScreenState extends State<ReviewDueScreen> {
+  final ProblemService _problemService = ProblemService();
+  Map<int, String?> _thumbnailUrls = {};
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final provider = Provider.of<ReviewDueProvider>(context, listen: false);
+      if (provider.data == null) {
+        await provider.fetchReviewDue();
+      }
+      if (provider.data != null) {
+        await _loadThumbnails(provider.data!.problems);
+      }
+    });
+  }
+
+  Future<void> _loadThumbnails(List<ReviewDueProblemModel> problems) async {
+    if (problems.isEmpty) return;
+    final entries = await Future.wait(
+      problems.map((p) async {
+        try {
+          final model = await _problemService.getProblem(
+            p.problemId,
+            showErrorSnackBar: false,
+          );
+          final url = model.problemImageDataList?.isNotEmpty == true
+              ? model.problemImageDataList!.first.imageUrl
+              : null;
+          return MapEntry(p.problemId, url);
+        } catch (_) {
+          return MapEntry(p.problemId, null);
+        }
+      }),
+    );
+    if (!mounted) return;
+    setState(() {
+      _thumbnailUrls = Map.fromEntries(entries);
+    });
+  }
+
+  Future<void> _refresh() async {
+    final provider = Provider.of<ReviewDueProvider>(context, listen: false);
+    await provider.fetchReviewDue();
+    if (provider.data != null) {
+      await _loadThumbnails(provider.data!.problems);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeHandler>(context);
+    final reviewDueProvider = Provider.of<ReviewDueProvider>(context);
+    final data = reviewDueProvider.data;
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: true,
+        title: StandardText(
+          text: '추천 복습 문제',
+          fontSize: 18,
+          color: themeProvider.primaryColor,
+        ),
+      ),
+      body: reviewDueProvider.isLoading && data == null
+          ? Center(
+              child: CircularProgressIndicator(
+                color: themeProvider.primaryColor,
+              ),
+            )
+          : data == null || data.problems.isEmpty
+              ? _buildEmptyState(themeProvider)
+              : RefreshIndicator(
+                  color: themeProvider.primaryColor,
+                  onRefresh: _refresh,
+                  child: ListView(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+                    children: [
+                      _buildHeader(data, themeProvider),
+                      const SizedBox(height: 16),
+                      ...data.problems.map(
+                        (p) => _buildProblemTile(context, p, themeProvider),
+                      ),
+                    ],
+                  ),
+                ),
+    );
+  }
+
+  Widget _buildHeader(ReviewDueResponse data, ThemeHandler themeProvider) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: themeProvider.primaryColor.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    StandardText(
+                      text: '추천 복습 문제 ',
+                      fontSize: 14,
+                      color: Colors.black87,
+                    ),
+                    StandardText(
+                      text: '${data.dueCount}개',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: themeProvider.primaryColor,
+                    ),
+                  ],
+                ),
+                if (data.overdueCount > 0) ...[
+                  const SizedBox(height: 3),
+                  Row(
+                    children: [
+                      Icon(Icons.warning_amber_rounded,
+                          size: 13, color: Colors.orange.shade600),
+                      const SizedBox(width: 4),
+                      StandardText(
+                        text: '이 중 ${data.overdueCount}개는 밀린 문제예요',
+                        fontSize: 12,
+                        color: Colors.orange.shade700,
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+          Icon(Icons.auto_stories_outlined,
+              color: themeProvider.primaryColor.withValues(alpha: 0.5),
+              size: 28),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProblemTile(
+    BuildContext context,
+    ReviewDueProblemModel problem,
+    ThemeHandler themeProvider,
+  ) {
+    final isMastered = problem.consecutiveCorrectCount >= 3;
+    final isOverdue = problem.nextReviewAt != null &&
+        problem.nextReviewAt!.isBefore(
+          DateTime.now().subtract(const Duration(days: 1)),
+        );
+    final imageUrl = _thumbnailUrls[problem.problemId];
+    final title = problem.reference?.isNotEmpty == true
+        ? problem.reference!
+        : problem.memo?.isNotEmpty == true
+            ? problem.memo!
+            : '제목 없음';
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: GestureDetector(
+        onTap: () async {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) =>
+                  ProblemDetailScreen(problemId: problem.problemId),
+            ),
+          );
+          if (!mounted) return;
+          _refresh();
+        },
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.grey.withValues(alpha: 0.2),
+                spreadRadius: 1,
+                blurRadius: 5,
+                offset: const Offset(0, 3),
+              ),
+            ],
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              // 썸네일
+              Container(
+                width: 50,
+                height: 70,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.grey[300]!, width: 0.8),
+                ),
+                clipBehavior: Clip.antiAlias,
+                child: DisplayImage(
+                  imagePath: imageUrl,
+                  fit: BoxFit.cover,
+                ),
+              ),
+              const SizedBox(width: 14),
+              // 텍스트 영역
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    StandardText(
+                      text: title,
+                      fontSize: 16,
+                      color: Colors.black,
+                    ),
+                    if (problem.memo?.isNotEmpty == true &&
+                        problem.reference?.isNotEmpty == true) ...[
+                      const SizedBox(height: 2),
+                      StandardText(
+                        text: problem.memo!,
+                        fontSize: 12,
+                        color: Colors.grey[500]!,
+                      ),
+                    ],
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        _buildProgressDots(
+                            problem.consecutiveCorrectCount, themeProvider),
+                        const SizedBox(width: 8),
+                        if (isMastered)
+                          _buildChip('마스터드', Colors.amber.shade700),
+                        if (isOverdue && !isMastered)
+                          _buildChip('밀린 문제', Colors.orange.shade600),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              Icon(Icons.chevron_right, size: 20, color: Colors.grey[400]),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProgressDots(int count, ThemeHandler themeProvider) {
+    return Row(
+      children: List.generate(3, (i) {
+        final filled = i < count;
+        return Container(
+          width: 18,
+          height: 4,
+          margin: const EdgeInsets.only(right: 3),
+          decoration: BoxDecoration(
+            color: filled
+                ? themeProvider.primaryColor
+                : Colors.grey.shade200,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        );
+      }),
+    );
+  }
+
+  Widget _buildChip(String text, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: StandardText(
+        text: text,
+        fontSize: 10,
+        fontWeight: FontWeight.w700,
+        color: color,
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(ThemeHandler themeProvider) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.check_circle_outline,
+            size: 64,
+            color: themeProvider.primaryColor.withValues(alpha: 0.35),
+          ),
+          const SizedBox(height: 16),
+          const StandardText(
+            text: '추천 복습 문제가 없어요',
+            fontSize: 16,
+            color: Colors.black54,
+          ),
+          const SizedBox(height: 6),
+          const StandardText(
+            text: '문제를 풀면 자동으로 복습 일정이 생겨요',
+            fontSize: 13,
+            color: Colors.black38,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/Screen/ReviewDue/ReviewDueScreen.dart
+++ b/lib/Screen/ReviewDue/ReviewDueScreen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ono/Model/Problem/ReviewDueProblemModel.dart';
-import 'package:ono/Module/Image/DisplayImage.dart';
+import 'package:ono/Model/Problem/ProblemModel.dart';
+import 'package:ono/Module/Problem/ProblemThumbnailCard.dart';
 import 'package:ono/Module/Text/StandardText.dart';
 import 'package:ono/Module/Theme/ThemeHandler.dart';
 import 'package:ono/Provider/ReviewDueProvider.dart';
@@ -17,7 +18,7 @@ class ReviewDueScreen extends StatefulWidget {
 
 class _ReviewDueScreenState extends State<ReviewDueScreen> {
   final ProblemService _problemService = ProblemService();
-  Map<int, String?> _thumbnailUrls = {};
+  Map<int, ProblemModel> _problemDetails = {};
 
   @override
   void initState() {
@@ -28,12 +29,12 @@ class _ReviewDueScreenState extends State<ReviewDueScreen> {
         await provider.fetchReviewDue();
       }
       if (provider.data != null) {
-        await _loadThumbnails(provider.data!.problems);
+        await _loadProblemDetails(provider.data!.problems);
       }
     });
   }
 
-  Future<void> _loadThumbnails(List<ReviewDueProblemModel> problems) async {
+  Future<void> _loadProblemDetails(List<ReviewDueProblemModel> problems) async {
     if (problems.isEmpty) return;
     final entries = await Future.wait(
       problems.map((p) async {
@@ -42,18 +43,16 @@ class _ReviewDueScreenState extends State<ReviewDueScreen> {
             p.problemId,
             showErrorSnackBar: false,
           );
-          final url = model.problemImageDataList?.isNotEmpty == true
-              ? model.problemImageDataList!.first.imageUrl
-              : null;
-          return MapEntry(p.problemId, url);
+          return MapEntry(p.problemId, model);
         } catch (_) {
-          return MapEntry(p.problemId, null);
+          return null;
         }
       }),
     );
     if (!mounted) return;
     setState(() {
-      _thumbnailUrls = Map.fromEntries(entries);
+      _problemDetails =
+          Map.fromEntries(entries.whereType<MapEntry<int, ProblemModel>>());
     });
   }
 
@@ -61,7 +60,7 @@ class _ReviewDueScreenState extends State<ReviewDueScreen> {
     final provider = Provider.of<ReviewDueProvider>(context, listen: false);
     await provider.fetchReviewDue();
     if (provider.data != null) {
-      await _loadThumbnails(provider.data!.problems);
+      await _loadProblemDetails(provider.data!.problems);
     }
   }
 
@@ -123,7 +122,7 @@ class _ReviewDueScreenState extends State<ReviewDueScreen> {
               children: [
                 Row(
                   children: [
-                    StandardText(
+                    const StandardText(
                       text: '추천 복습 문제 ',
                       fontSize: 14,
                       color: Colors.black87,
@@ -167,17 +166,17 @@ class _ReviewDueScreenState extends State<ReviewDueScreen> {
     ReviewDueProblemModel problem,
     ThemeHandler themeProvider,
   ) {
-    final isMastered = problem.consecutiveCorrectCount >= 3;
-    final isOverdue = problem.nextReviewAt != null &&
-        problem.nextReviewAt!.isBefore(
-          DateTime.now().subtract(const Duration(days: 1)),
-        );
-    final imageUrl = _thumbnailUrls[problem.problemId];
-    final title = problem.reference?.isNotEmpty == true
-        ? problem.reference!
-        : problem.memo?.isNotEmpty == true
-            ? problem.memo!
-            : '제목 없음';
+    final detail = _problemDetails[problem.problemId];
+    final imageUrl = detail?.problemImageDataList?.isNotEmpty == true
+        ? detail!.problemImageDataList!.first.imageUrl
+        : null;
+    final title = detail?.reference?.isNotEmpty == true
+        ? detail!.reference!
+        : problem.reference?.isNotEmpty == true
+            ? problem.reference!
+            : problem.memo?.isNotEmpty == true
+                ? problem.memo!
+                : '제목 없음';
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 10),
@@ -186,118 +185,20 @@ class _ReviewDueScreenState extends State<ReviewDueScreen> {
           await Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (_) =>
-                  ProblemDetailScreen(problemId: problem.problemId),
+              builder: (_) => ProblemDetailScreen(problemId: problem.problemId),
             ),
           );
           if (!mounted) return;
           _refresh();
         },
-        child: Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(12),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.grey.withValues(alpha: 0.2),
-                spreadRadius: 1,
-                blurRadius: 5,
-                offset: const Offset(0, 3),
-              ),
-            ],
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              // 썸네일
-              Container(
-                width: 50,
-                height: 70,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.grey[300]!, width: 0.8),
-                ),
-                clipBehavior: Clip.antiAlias,
-                child: DisplayImage(
-                  imagePath: imageUrl,
-                  fit: BoxFit.cover,
-                ),
-              ),
-              const SizedBox(width: 14),
-              // 텍스트 영역
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    StandardText(
-                      text: title,
-                      fontSize: 16,
-                      color: Colors.black,
-                    ),
-                    if (problem.memo?.isNotEmpty == true &&
-                        problem.reference?.isNotEmpty == true) ...[
-                      const SizedBox(height: 2),
-                      StandardText(
-                        text: problem.memo!,
-                        fontSize: 12,
-                        color: Colors.grey[500]!,
-                      ),
-                    ],
-                    const SizedBox(height: 8),
-                    Row(
-                      children: [
-                        _buildProgressDots(
-                            problem.consecutiveCorrectCount, themeProvider),
-                        const SizedBox(width: 8),
-                        if (isMastered)
-                          _buildChip('마스터드', Colors.amber.shade700),
-                        if (isOverdue && !isMastered)
-                          _buildChip('밀린 문제', Colors.orange.shade600),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              Icon(Icons.chevron_right, size: 20, color: Colors.grey[400]),
-            ],
-          ),
+        child: ProblemThumbnailCard(
+          title: title,
+          imageUrl: imageUrl,
+          tags: detail?.tags ?? const [],
+          solveCount: detail?.solveCount ?? problem.consecutiveCorrectCount,
+          lastSolvedAt: detail?.lastSolvedAt,
+          themeProvider: themeProvider,
         ),
-      ),
-    );
-  }
-
-  Widget _buildProgressDots(int count, ThemeHandler themeProvider) {
-    return Row(
-      children: List.generate(3, (i) {
-        final filled = i < count;
-        return Container(
-          width: 18,
-          height: 4,
-          margin: const EdgeInsets.only(right: 3),
-          decoration: BoxDecoration(
-            color: filled
-                ? themeProvider.primaryColor
-                : Colors.grey.shade200,
-            borderRadius: BorderRadius.circular(2),
-          ),
-        );
-      }),
-    );
-  }
-
-  Widget _buildChip(String text, Color color) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: StandardText(
-        text: text,
-        fontSize: 10,
-        fontWeight: FontWeight.w700,
-        color: color,
       ),
     );
   }

--- a/lib/Screen/User/MyPageScreen.dart
+++ b/lib/Screen/User/MyPageScreen.dart
@@ -146,6 +146,26 @@ class _SettingScreenState extends State<SettingScreen> {
                     onTermsTap: () {
                       UrlLauncher.launchUserTemPageURL();
                     },
+                    notificationEnabled:
+                        userProvider.userInfoModel?.notificationEnabled ?? true,
+                    onNotificationChanged: (value) async {
+                      try {
+                        await Provider.of<UserProvider>(context, listen: false)
+                            .updateNotificationSettings(value);
+                      } catch (_) {
+                        if (!context.mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: StandardText(
+                              text: '알림 설정 변경에 실패했습니다. 다시 시도해주세요.',
+                              fontSize: 14,
+                              color: Colors.white,
+                            ),
+                            backgroundColor: Colors.red,
+                          ),
+                        );
+                      }
+                    },
                   ),
 
                   // 로그아웃/회원탈퇴 (흐릿한 텍스트)

--- a/lib/Screen/User/Widget/SettingMenuButtons.dart
+++ b/lib/Screen/User/Widget/SettingMenuButtons.dart
@@ -8,6 +8,8 @@ class SettingMenuButtons extends StatelessWidget {
   final VoidCallback onGuideTap;
   final VoidCallback onFeedbackTap;
   final VoidCallback onTermsTap;
+  final bool notificationEnabled;
+  final ValueChanged<bool> onNotificationChanged;
 
   const SettingMenuButtons({
     super.key,
@@ -16,6 +18,8 @@ class SettingMenuButtons extends StatelessWidget {
     required this.onGuideTap,
     required this.onFeedbackTap,
     required this.onTermsTap,
+    required this.notificationEnabled,
+    required this.onNotificationChanged,
   });
 
   @override
@@ -39,6 +43,14 @@ class SettingMenuButtons extends StatelessWidget {
       ),
       child: Column(
         children: [
+          _buildToggleItem(
+            context: context,
+            icon: Icons.notifications_outlined,
+            title: '복습 알림',
+            value: notificationEnabled,
+            onChanged: onNotificationChanged,
+          ),
+          Divider(height: screenHeight * 0.02, color: Colors.grey[300]),
           _buildMenuItem(
             context: context,
             icon: Icons.edit,
@@ -65,6 +77,48 @@ class SettingMenuButtons extends StatelessWidget {
             icon: Icons.description_outlined,
             title: 'OnO 이용약관',
             onTap: onTermsTap,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToggleItem({
+    required BuildContext context,
+    required IconData icon,
+    required String title,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    double screenHeight = MediaQuery.of(context).size.height;
+
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        vertical: screenHeight * 0.002,
+        horizontal: screenHeight * 0.01,
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: themeProvider.primaryColor),
+          SizedBox(width: screenHeight * 0.015),
+          Expanded(
+            child: StandardText(
+              text: title,
+              fontSize: 14,
+              color: Colors.black87,
+            ),
+          ),
+          Transform.scale(
+            scale: 0.8,
+            child: Switch(
+              value: value,
+              activeThumbColor: themeProvider.primaryColor,
+              activeTrackColor: themeProvider.primaryColor.withValues(alpha: 0.5),
+              inactiveTrackColor: Colors.grey.shade300,
+              inactiveThumbColor: Colors.grey,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              onChanged: onChanged,
+            ),
           ),
         ],
       ),

--- a/lib/Service/Api/Problem/ProblemService.dart
+++ b/lib/Service/Api/Problem/ProblemService.dart
@@ -6,6 +6,7 @@ import 'package:ono/Model/Common/PaginatedResponse.dart';
 import 'package:ono/Model/Problem/ProblemAnalysisModel.dart';
 import 'package:ono/Model/Problem/ProblemModel.dart';
 import 'package:ono/Model/Problem/ProblemRegisterModel.dart';
+import 'package:ono/Model/Problem/ReviewDueProblemModel.dart';
 
 import '../../../Config/AppConfig.dart';
 import '../HttpService.dart';
@@ -262,5 +263,13 @@ class ProblemService {
       data,
       (json) => ProblemModel.fromJson(json),
     );
+  }
+
+  Future<ReviewDueResponse> getReviewDueProblems() async {
+    final data = await httpService.sendRequest(
+      method: 'GET',
+      url: '${AppConfig.baseUrl}/api/problems/review-due',
+    );
+    return ReviewDueResponse.fromJson(data as Map<String, dynamic>);
   }
 }

--- a/lib/Service/Api/User/UserService.dart
+++ b/lib/Service/Api/User/UserService.dart
@@ -47,6 +47,14 @@ class UserService {
     );
   }
 
+  Future<void> updateNotificationSettings(bool enabled) async {
+    await httpService.sendRequest(
+      method: 'PATCH',
+      url: '${AppConfig.baseUrl}/api/users/notification-settings',
+      body: {'notificationEnabled': enabled},
+    );
+  }
+
   Future<void> logoutAccount() async {
     await httpService.sendRequest(
       method: 'POST',

--- a/lib/Util/AppNavigator.dart
+++ b/lib/Util/AppNavigator.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+class AppNavigator {
+  static final navigatorKey = GlobalKey<NavigatorState>();
+}

--- a/lib/Util/NotificationService.dart
+++ b/lib/Util/NotificationService.dart
@@ -4,11 +4,14 @@ import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
 import 'package:ono/Config/AppConfig.dart';
 
 import '../Config/firebase_options.dart';
+import '../Screen/ReviewDue/ReviewDueScreen.dart';
 import '../Service/Api/HttpService.dart';
 import 'AppErrorReporter.dart';
+import 'AppNavigator.dart';
 
 class NotificationService {
   NotificationService._();
@@ -56,13 +59,22 @@ class NotificationService {
     // 포그라운드 메시지
     FirebaseMessaging.onMessage.listen((msg) {
       log('Foreground message: ${msg.notification?.title}');
-      // TODO: 스낵바나 다이얼로그로 표시
     });
 
-    // 백그라운드/종료 상태에서 알림 탭 클릭
+    // 백그라운드 상태에서 알림 탭
     FirebaseMessaging.onMessageOpenedApp.listen((msg) {
-      log('Notification clicked, data: ${msg.data}');
-      // TODO: Navigator.pushNamed(...) 등으로 화면 이동
+      log('Notification tapped (background), data: ${msg.data}');
+      _handleNotificationNavigation(msg.data);
+    });
+
+    // 종료 상태에서 알림 탭으로 앱 실행
+    FirebaseMessaging.instance.getInitialMessage().then((msg) {
+      if (msg != null) {
+        log('Notification tapped (terminated), data: ${msg.data}');
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _handleNotificationNavigation(msg.data);
+        });
+      }
     });
 
     if (!_tokenRefreshListenerConfigured) {
@@ -79,6 +91,20 @@ class NotificationService {
           );
         }
       });
+    }
+  }
+
+  void _handleNotificationNavigation(Map<String, dynamic> data) {
+    final type = data['type'] as String?;
+    final navigator = AppNavigator.navigatorKey.currentState;
+    if (navigator == null) return;
+
+    if (type == 'review_due') {
+      navigator.push(
+        MaterialPageRoute(builder: (_) => const ReviewDueScreen()),
+      );
+    } else if (type == 'reengagement' || type == 'reengagement_monthly') {
+      navigator.popUntil((route) => route.isFirst);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,13 +21,15 @@ import 'Config/AppConfig.dart';
 import 'Config/firebase_options.dart';
 import 'Provider/PracticeNoteProvider.dart';
 import 'Provider/ProblemsProvider.dart';
+import 'Provider/ReviewDueProvider.dart';
 import 'Provider/UserProvider.dart';
 import 'Screen/Folder/DirectoryScreen.dart';
 import 'Screen/PracticeNote/PracticeThumbnailScreen.dart';
 import 'Screen/User/MyPageScreen.dart';
 import 'Util/AppErrorReporter.dart';
-import 'Util/NotificationService.dart';
+import 'Util/AppNavigator.dart';
 import 'Util/AppSnackBar.dart';
+import 'Util/NotificationService.dart';
 
 Future<void> main() async {
   await runZonedGuarded<Future<void>>(
@@ -130,6 +132,7 @@ Future<void> _bootstrapApp() async {
           create: (context) => ThemeHandler()..loadColors(),
         ),
         ChangeNotifierProvider(create: (_) => ScreenIndexProvider()),
+        ChangeNotifierProvider(create: (_) => ReviewDueProvider()),
       ],
       child: const MyApp(),
     ),
@@ -150,6 +153,7 @@ class MyApp extends StatelessWidget {
       title: 'OnO',
       theme: _buildThemeData(context),
       scaffoldMessengerKey: AppSnackBar.messengerKey,
+      navigatorKey: AppNavigator.navigatorKey,
       navigatorObservers: <NavigatorObserver>[observer],
       home: SplashScreen(),
       debugShowCheckedModeBanner: false,


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 추천 복습 문제 조회 기능을 추가하고, FCM 알림 클릭 시 추천 복습 문제 화면으로 이동하도록 라우팅을 연결했습니다.
- 오답노트 썸네일 카드에 `solveCount` 기반 복습 게이지와 `lastSolvedAt` 기반 최근 복습일 정보를 표시했습니다.
- 폴더 문제 목록, 검색 결과, 추천 복습 문제, 복습 세트 상세, 복습 세트 문제 선택 화면의 오답노트 썸네일 UI를 공통 카드로 통일했습니다.
- 백엔드 필드 변경에 맞춰 문제 모델의 `reviewCount`를 `solveCount`로 반영하고 `lastSolvedAt` 필드를 추가했습니다.
- 복습 세트에 추가하기 바텀시트의 상태별 디자인을 개선했습니다.
  - 이미 포함된 세트는 초록 계열 상태로 표시
  - 선택한 세트는 테마 컬러로 강조
  - 문구를 `이미 세트에 포함했습니다.`로 수정

### 스크린샷 (선택)

- 없음

## 검증

- `dart analyze` 변경 파일 대상 실행
  - 신규 컴파일 에러 없음
  - 기존 파일명 규칙, deprecated, async gap 관련 info/warning은 남아 있음
- `flutter test` 실행
  - 기존 `test/widget_test.dart`가 기본 counter 테스트이며 `MyApp`을 Provider 없이 직접 렌더링해 `Provider<ThemeHandler>`를 찾지 못하는 기존 테스트 구조 문제로 실패
