### PR TITLE
[Release] 3.6.0 버전 출시

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -308,13 +308,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -345,13 +341,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -536,7 +528,7 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aisip.OnO;
@@ -557,7 +549,7 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.mvpFront.RunnerTests;
@@ -576,7 +568,7 @@
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.mvpFront.RunnerTests;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -308,9 +308,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -341,9 +345,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -498,11 +506,11 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEVELOPMENT_TEAM = D44353AJ7W;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 3.5.0;
-				FLUTTER_BUILD_NUMBER = 2;
+				FLUTTER_BUILD_NAME = 3.6.0;
+				FLUTTER_BUILD_NUMBER = 1;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OnO;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -510,7 +518,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aisip.OnO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -700,11 +708,11 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEVELOPMENT_TEAM = D44353AJ7W;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 3.5.0;
-				FLUTTER_BUILD_NUMBER = 2;
+				FLUTTER_BUILD_NAME = 3.6.0;
+				FLUTTER_BUILD_NUMBER = 1;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OnO;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -712,7 +720,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aisip.OnO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -732,11 +740,11 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEVELOPMENT_TEAM = D44353AJ7W;
 				ENABLE_BITCODE = NO;
-				FLUTTER_BUILD_NAME = 3.5.0;
-				FLUTTER_BUILD_NUMBER = 2;
+				FLUTTER_BUILD_NAME = 3.6.0;
+				FLUTTER_BUILD_NUMBER = 1;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = OnO;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -744,7 +752,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.5.0;
+				MARKETING_VERSION = 3.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.aisip.OnO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/lib/Constants/ErrorMessages.dart
+++ b/lib/Constants/ErrorMessages.dart
@@ -41,6 +41,7 @@ class ErrorMessages {
   static const String folderUserUnmatched = '폴더를 소유한 유저가 아닙니다.';
   static const String rootFolderNotExist = '루트 폴더가 존재하지 않습니다.';
   static const String rootFolderCannotRemove = '루트 폴더는 삭제할 수 없습니다.';
+  static const String rootFolderCannotUpdate = '책장 이름은 변경할 수 없습니다.';
 
   static const String practiceNoteNotFound = '복습 세트를 찾을 수 없습니다.';
 

--- a/lib/Module/Util/FolderPickerDialog.dart
+++ b/lib/Module/Util/FolderPickerDialog.dart
@@ -74,7 +74,7 @@ class _FolderPickerDialogState extends State<FolderPickerDialog> {
       final root = foldersProvider.rootFolder!;
       _rootNode = FolderTreeNode(
         folderId: root.folderId,
-        folderName: root.folderName,
+        folderName: '책장',
         parentFolderId: null,
       );
 
@@ -82,7 +82,7 @@ class _FolderPickerDialogState extends State<FolderPickerDialog> {
       _rootNode!.isExpanded = true;
 
       // 캐시에 저장
-      FolderPickerDialog._cachedFolderNames[root.folderId] = root.folderName;
+      FolderPickerDialog._cachedFolderNames[root.folderId] = '책장';
 
       _selectedFolderId ??= root.folderId;
 

--- a/lib/Module/Util/FolderPickerWidget.dart
+++ b/lib/Module/Util/FolderPickerWidget.dart
@@ -32,6 +32,9 @@ class _FolderPickerWidgetState extends State<FolderPickerWidget> {
     final selectedId = widget.selectedId;
     if (selectedId == null) return '책장';
 
+    final rootFolderId = foldersProvider.rootFolder?.folderId;
+    if (selectedId == rootFolderId) return '책장';
+
     final currentFolder = foldersProvider.currentFolder;
     if (currentFolder != null && currentFolder.folderId == selectedId) {
       return currentFolder.folderName;

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -942,18 +942,20 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
                         _showCreateFolderDialog();
                       },
                     ),
-                    const SizedBox(height: 8),
-                    _buildActionItem(
-                      icon: Icons.drive_file_rename_outline,
-                      iconColor: themeProvider.primaryColor,
-                      title: '공책 이름 수정하기',
-                      onTap: () {
-                        Navigator.pop(context);
-                        FirebaseAnalytics.instance
-                            .logEvent(name: 'directory_rename_button_click');
-                        _showRenameFolderDialog(foldersProvider);
-                      },
-                    ),
+                    if (_currentFolder?.parentFolder?.folderId != null) ...[
+                      const SizedBox(height: 8),
+                      _buildActionItem(
+                        icon: Icons.drive_file_rename_outline,
+                        iconColor: themeProvider.primaryColor,
+                        title: '공책 이름 수정하기',
+                        onTap: () {
+                          Navigator.pop(context);
+                          FirebaseAnalytics.instance
+                              .logEvent(name: 'directory_rename_button_click');
+                          _showRenameFolderDialog(foldersProvider);
+                        },
+                      ),
+                    ],
                     const SizedBox(height: 8),
                     _buildActionItem(
                       icon: Icons.drive_file_move_outline,
@@ -1057,7 +1059,18 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
   ) async {
     final foldersProvider =
         Provider.of<FoldersProvider>(context, listen: false);
-    await foldersProvider.updateFolder(newName, _currentFolder!.folderId, null);
+    try {
+      await foldersProvider.updateFolder(newName, _currentFolder!.folderId, null);
+    } on ApiException catch (e) {
+      if (mounted) {
+        SnackBarDialog.showSnackBar(
+          context: context,
+          message: e.getUserMessage(),
+          backgroundColor: Colors.redAccent,
+        );
+      }
+      return;
+    }
 
     // 데이터 다시 로드
     await _loadFolderData();

--- a/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeProblemSelectionScreen.dart
@@ -802,6 +802,11 @@ class _PracticeProblemSelectionScreenState
     final screenWidth = MediaQuery.of(context).size.width;
     final isWide = screenWidth >= 600;
     final folderNameWidth = isWide ? 120.0 : screenWidth * 0.2;
+    final rootFolderId =
+        context.read<FoldersProvider>().rootFolder?.folderId;
+    final displayName = folder.folderId == rootFolderId
+        ? '책장'
+        : folder.folderName;
 
     return Opacity(
       opacity: isSelected ? 1.0 : 0.5, // 선택된 폴더가 아니라면 흐리게 표시
@@ -816,9 +821,9 @@ class _PracticeProblemSelectionScreenState
           SizedBox(
             width: folderNameWidth,
             child: StandardText(
-              text: folder.folderName.length > 10
-                  ? '${folder.folderName.substring(0, 10)}..'
-                  : folder.folderName,
+              text: displayName.length > 10
+                  ? '${displayName.substring(0, 10)}..'
+                  : displayName,
               fontSize: 14,
               color: Colors.black,
               textAlign: TextAlign.center,

--- a/lib/Screen/ProblemRegister/MultiProblemRegisterScreen.dart
+++ b/lib/Screen/ProblemRegister/MultiProblemRegisterScreen.dart
@@ -2139,6 +2139,9 @@ class _MultiProblemRegisterScreenState
         Provider.of<FoldersProvider>(context, listen: false);
     if (folderId == null) return '책장';
 
+    final rootFolderId = foldersProvider.rootFolder?.folderId;
+    if (folderId == rootFolderId) return '책장';
+
     final currentFolder = foldersProvider.currentFolder;
     if (currentFolder != null && currentFolder.folderId == folderId) {
       return currentFolder.folderName;

--- a/lib/Screen/ProblemShare/AchievementCardScreen.dart
+++ b/lib/Screen/ProblemShare/AchievementCardScreen.dart
@@ -72,7 +72,8 @@ class _AchievementCardScreenState extends State<AchievementCardScreen> {
 
       final result = await Share.shareXFiles(
         [XFile(file.path)],
-        text: 'OnO에서 이번 주 학습 결과야! 📚\n\nOnO 다운로드: https://ono-app.com/home',
+        text:
+            'OnO에서 이번 주 학습 결과야! 📚\n\nOnO에서 복습하기: https://ono-prod.seungminki.shop',
         sharePositionOrigin: Rect.fromPoints(
           Offset.zero,
           Offset(screenSize.width * 2 / 3, screenSize.height),

--- a/lib/Screen/ProblemShare/AnswerShareScreen.dart
+++ b/lib/Screen/ProblemShare/AnswerShareScreen.dart
@@ -299,7 +299,7 @@ class _AnswerShareScreenState extends State<AnswerShareScreen> {
       if (rect.size.width > 0 && rect.size.height > 0) {
         await Share.shareXFiles(
           [xFile],
-          text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home',
+          text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-prod.seungminki.shop',
           sharePositionOrigin: Rect.fromPoints(
             Offset.zero,
             Offset(size.width / 3 * 2, size.height),
@@ -309,7 +309,7 @@ class _AnswerShareScreenState extends State<AnswerShareScreen> {
         log('Invalid box size, defaulting to basic share...');
         await Share.shareXFiles(
           [xFile],
-          text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home',
+          text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-prod.seungminki.shop',
         );
       }
 

--- a/lib/Screen/ProblemShare/ProblemShareScreen.dart
+++ b/lib/Screen/ProblemShare/ProblemShareScreen.dart
@@ -308,7 +308,7 @@ class _ProblemShareScreenState extends State<ProblemShareScreen> {
       if (rect.size.width > 0 && rect.size.height > 0) {
         await Share.shareXFiles(
           [xFile],
-          text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home',
+          text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-prod.seungminki.shop',
           sharePositionOrigin: Rect.fromPoints(
             Offset.zero,
             Offset(size.width / 3 * 2, size.height),
@@ -317,7 +317,7 @@ class _ProblemShareScreenState extends State<ProblemShareScreen> {
       } else {
         log('Invalid box size, defaulting to basic share...');
         await Share.shareXFiles([xFile],
-            text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-app.com/home');
+            text: '내 오답노트야! 어때?\n\nOnO 다운로드: https://ono-prod.seungminki.shop');
       }
 
       if (mounted) {

--- a/lib/Screen/User/Widget/FrogCharacter.dart
+++ b/lib/Screen/User/Widget/FrogCharacter.dart
@@ -129,7 +129,7 @@ class _FrogCharacterState extends State<FrogCharacter>
           // 격려 메시지
           if (_showMessage && _displayMessage != null)
             Positioned(
-              top: -10,
+              bottom: widget.size * 0.82,
               child: AnimatedOpacity(
                 opacity: _showMessage ? 1.0 : 0.0,
                 duration: const Duration(milliseconds: 300),

--- a/lib/Screen/User/Widget/UserLevelCard.dart
+++ b/lib/Screen/User/Widget/UserLevelCard.dart
@@ -43,7 +43,9 @@ class UserLevelCard extends StatelessWidget {
     final bool isTabletLandscape = isTablet && screenWidth > screenHeight;
 
     final double donutSize = isTablet ? 120.0 : 82.0;
-    final double frogSize = isTablet ? 130.0 : 92.0;
+    final double labelFontSize = isTablet ? 16.0 : 14.0;
+    final double frogTopSpace = isTablet ? 14.0 : 10.0;
+    final double frogSize = donutSize + 8.0 + labelFontSize * 1.3 - frogTopSpace;
 
     int currentLevel = _getOverallLevel();
     int currentPoint = _getCurrentPoint();
@@ -83,8 +85,12 @@ class UserLevelCard extends StatelessWidget {
                 ),
               ),
               Expanded(
-                child: Center(
-                  child: FrogCharacter(level: currentLevel, size: frogSize),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(height: frogTopSpace),
+                    FrogCharacter(level: currentLevel, size: frogSize),
+                  ],
                 ),
               ),
             ],

--- a/lib/Util/ErrorMessageMapper.dart
+++ b/lib/Util/ErrorMessageMapper.dart
@@ -45,6 +45,8 @@ class ErrorMessageMapper {
         return ErrorMessages.rootFolderNotExist;
       case 5004:
         return ErrorMessages.rootFolderCannotRemove;
+      case 5005:
+        return ErrorMessages.rootFolderCannotUpdate;
       case 6001:
         return ErrorMessages.practiceNoteNotFound;
       case 7001:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.5.0+65
+version: 3.6.0+67
 
 environment:
   sdk: '>=3.3.3 <4.0.0'


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #이슈번호

## 📝 작업 내용

1. 오답노트 여러 장 한 번에 등록

- 이제 사진을 여러 장 선택해서 오답노트를 한 번에 등록할 수 있어요!
- 등록 화면에서 이미지를 확대해 확인하면서 문제를 입력할 수 있습니다.
- 문제마다 태그를 자동으로 추천해 드려요.
- 오답노트 추가 메뉴가 하나로 통합되어 더 간편하게 사용할 수 있어요.

2. 학습 성취 카드 공유 기능 추가

- 이번 주 나의 학습 결과를 예쁜 카드 이미지로 만들어 공유할 수 있어요!
- 복습 횟수, 정답률, 연속 학습일, 취약 과목 등 핵심 성과를 한눈에 확인할 수 있습니다.
- SNS나 메신저로 바로 공유할 수 있어요.

3. 학습 달력 기능 추가

- 날짜별 학습 기록을 달력으로 한눈에 확인할 수 있어요!
- 스탬프로 내가 공부한 날을 표시하고, 연속 학습일 스트릭을 이어가 보세요.
- 마이페이지에서 오늘까지의 연속 학습 현황을 바로 확인할 수 있습니다.

4. 마이페이지 성장 콘텐츠 중심으로 개편

- 마이페이지가 나의 성장을 한눈에 파악할 수 있도록 새롭게 개편되었어요.
- 학습 리포트, 달력, 스트릭 등 성장 관련 콘텐츠가 강화되었습니다.
- 태블릿 화면에서도 더 보기 편한 레이아웃으로 개선되었어요.

5. 안정성 개선

- 알림을 클릭했을 때 화면이 비정상적으로 쌓이던 문제를 수정했습니다.
- 루트 폴더 이름이 올바르게 '책장'으로 표시됩니다.
- OnO 공유 링크가 잘못 연결되던 문제를 해결했어요.