### PR TITLE
[Feat] 온보딩 튜토리얼 도입 - 화면별 안내 오버레이 및 마이페이지 다시 보기 지원

### DIFF
--- a/lib/Provider/TutorialProvider.dart
+++ b/lib/Provider/TutorialProvider.dart
@@ -20,6 +20,7 @@ class TutorialProvider extends ChangeNotifier {
   bool get isVisible => _status != TutorialStatus.idle;
   bool get isIntro => _status == TutorialStatus.intro;
   bool get isRunning => _status == TutorialStatus.running;
+  bool get isOutro => _status == TutorialStatus.outro;
 
   Future<void> showAutoIntroIfNeeded({
     required UserInfoModel? userInfo,
@@ -67,6 +68,13 @@ class TutorialProvider extends ChangeNotifier {
   }
 
   void previous() {
+    if (_status == TutorialStatus.outro) {
+      _status = TutorialStatus.running;
+      _logStepEvent('tutorial_previous');
+      _logStepEvent('tutorial_step_show');
+      notifyListeners();
+      return;
+    }
     if (_status != TutorialStatus.running || _currentStepIndex == 0) return;
     _logStepEvent('tutorial_previous');
     _currentStepIndex -= 1;
@@ -78,7 +86,9 @@ class TutorialProvider extends ChangeNotifier {
     if (_status != TutorialStatus.running) return;
     _logStepEvent('tutorial_next');
     if (_currentStepIndex >= tutorialSteps.length - 1) {
-      await complete();
+      _status = TutorialStatus.outro;
+      _logEvent('tutorial_outro_show');
+      notifyListeners();
       return;
     }
     _currentStepIndex += 1;

--- a/lib/Provider/TutorialProvider.dart
+++ b/lib/Provider/TutorialProvider.dart
@@ -1,0 +1,138 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/material.dart';
+
+import '../Model/User/UserInfoModel.dart';
+import '../Screen/Tutorial/TutorialStep.dart';
+import '../Screen/Tutorial/TutorialStorage.dart';
+
+class TutorialProvider extends ChangeNotifier {
+  final TutorialStorage _storage = TutorialStorage();
+
+  TutorialStatus _status = TutorialStatus.idle;
+  TutorialLaunchSource? _source;
+  int _currentStepIndex = 0;
+  int? _userId;
+
+  TutorialStatus get status => _status;
+  TutorialLaunchSource? get source => _source;
+  int get currentStepIndex => _currentStepIndex;
+  TutorialStep get currentStep => tutorialSteps[_currentStepIndex];
+  bool get isVisible => _status != TutorialStatus.idle;
+  bool get isIntro => _status == TutorialStatus.intro;
+  bool get isRunning => _status == TutorialStatus.running;
+
+  Future<void> showAutoIntroIfNeeded({
+    required UserInfoModel? userInfo,
+    required bool isFirstLogin,
+  }) async {
+    if (_status != TutorialStatus.idle || !isFirstLogin || userInfo == null) {
+      return;
+    }
+
+    final createdAt = userInfo.createdAt;
+    final now = DateTime.now();
+    final isRecentlyCreated = createdAt != null &&
+        createdAt.isAfter(now.subtract(const Duration(minutes: 30))) &&
+        createdAt.isBefore(now.add(const Duration(minutes: 5)));
+    if (!isRecentlyCreated) return;
+
+    final completed = await _storage.isCompleted(userInfo.userId);
+    if (completed) return;
+
+    _userId = userInfo.userId;
+    _source = TutorialLaunchSource.firstSignup;
+    _status = TutorialStatus.intro;
+    _currentStepIndex = 0;
+    _logEvent('tutorial_intro_show');
+    notifyListeners();
+  }
+
+  void showReplayIntro(int userId) {
+    _userId = userId;
+    _source = TutorialLaunchSource.settingsReplay;
+    _status = TutorialStatus.intro;
+    _currentStepIndex = 0;
+    _logEvent('tutorial_replay_from_settings');
+    _logEvent('tutorial_intro_show');
+    notifyListeners();
+  }
+
+  void start() {
+    if (_status != TutorialStatus.intro) return;
+    _status = TutorialStatus.running;
+    _currentStepIndex = 0;
+    _logEvent('tutorial_start');
+    _logStepEvent('tutorial_step_show');
+    notifyListeners();
+  }
+
+  void previous() {
+    if (_status != TutorialStatus.running || _currentStepIndex == 0) return;
+    _logStepEvent('tutorial_previous');
+    _currentStepIndex -= 1;
+    _logStepEvent('tutorial_step_show');
+    notifyListeners();
+  }
+
+  Future<void> next() async {
+    if (_status != TutorialStatus.running) return;
+    _logStepEvent('tutorial_next');
+    if (_currentStepIndex >= tutorialSteps.length - 1) {
+      await complete();
+      return;
+    }
+    _currentStepIndex += 1;
+    _logStepEvent('tutorial_step_show');
+    notifyListeners();
+  }
+
+  Future<void> skip() async {
+    if (_status == TutorialStatus.running) {
+      _logStepEvent('tutorial_skip');
+    } else {
+      _logEvent('tutorial_skip');
+    }
+    await _markCompletedIfAuto();
+    _reset();
+  }
+
+  Future<void> complete() async {
+    _logEvent('tutorial_complete');
+    await _markCompletedIfAuto();
+    _reset();
+  }
+
+  Future<void> _markCompletedIfAuto() async {
+    if (_source != TutorialLaunchSource.firstSignup || _userId == null) return;
+    await _storage.markCompleted(_userId!);
+  }
+
+  void _reset() {
+    _status = TutorialStatus.idle;
+    _source = null;
+    _currentStepIndex = 0;
+    notifyListeners();
+  }
+
+  void _logStepEvent(String name) {
+    FirebaseAnalytics.instance.logEvent(
+      name: name,
+      parameters: {
+        'step_index': _currentStepIndex,
+        'step_id': currentStep.id,
+        'source': _source?.name ?? 'unknown',
+        'version': currentTutorialVersion,
+      },
+    );
+  }
+
+  void _logEvent(String name) {
+    FirebaseAnalytics.instance.logEvent(
+      name: name,
+      parameters: {
+        'source': _source?.name ?? 'unknown',
+        'version': currentTutorialVersion,
+      },
+    );
+  }
+}

--- a/lib/Screen/Folder/DirectoryScreen.dart
+++ b/lib/Screen/Folder/DirectoryScreen.dart
@@ -32,12 +32,17 @@ import '../ProblemRegister/MultiProblemRegisterScreen.dart';
 import '../ProblemRegister/ProblemRegisterScreen.dart';
 import '../ProblemSearch/TagProblemSearchScreen.dart';
 import '../ReviewDue/ReviewDueScreen.dart';
-import 'UserGuideScreen.dart';
+import '../Tutorial/TutorialTargets.dart';
 
 class DirectoryScreen extends StatefulWidget {
   final int? folderId; // 이 화면이 표시할 폴더 ID
+  final TutorialTargets? tutorialTargets;
 
-  const DirectoryScreen({super.key, this.folderId});
+  const DirectoryScreen({
+    super.key,
+    this.folderId,
+    this.tutorialTargets,
+  });
 
   @override
   _DirectoryScreenState createState() => _DirectoryScreenState();
@@ -45,7 +50,6 @@ class DirectoryScreen extends StatefulWidget {
 
 class _DirectoryScreenState extends State<DirectoryScreen> {
   static const double _dialogMaxWidth = 420;
-  bool modalShown = false;
   bool _isSelectionMode = false; // 선택 모드 활성화 여부
   final List<int> _selectedFolderIds = []; // 선택된 폴더 ID 리스트
   final List<int> _selectedProblemIds = []; // 선택된 문제 ID 리스트
@@ -86,19 +90,11 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     _scrollController.addListener(_onScroll);
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final userProvider = Provider.of<UserProvider>(context, listen: false);
-
       // 이 화면의 폴더 데이터 로드
       await _loadFolderData();
 
       if (widget.folderId == null) {
         Provider.of<ReviewDueProvider>(context, listen: false).fetchReviewDue();
-      }
-
-      if (!modalShown && userProvider.isFirstLogin && widget.folderId == null) {
-        modalShown = true;
-        userProvider.changeIsFirstLogin();
-        _showUserGuideModal();
       }
     });
   }
@@ -451,39 +447,6 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     }
   }
 
-  void _showUserGuideModal() async {
-    FirebaseAnalytics.instance.logEvent(name: 'show_user_guide_modal');
-
-    final openTime = DateTime.now();
-    await showModalBottomSheet(
-      context: context,
-      isScrollControlled: true, // 스크롤 가능 모달 설정
-      backgroundColor: Colors.transparent, // 투명 배경
-      isDismissible: false,
-      builder: (BuildContext context) {
-        return TapRegion(
-            onTapOutside: (_) {
-              // Workaround for iPadOS 26.1 bug: https://github.com/flutter/flutter/issues/177992
-              if (DateTime.now().difference(openTime) <
-                  const Duration(milliseconds: 500)) {
-                return;
-              }
-              if (Navigator.canPop(context)) {
-                Navigator.pop(context);
-              }
-            },
-            child: FractionallySizedBox(
-              heightFactor: 0.6, // 화면 높이의 50% 차지
-              child: UserGuideScreen(
-                onFinish: () {
-                  Navigator.of(context).pop(); // 모달 닫기
-                },
-              ),
-            ));
-      },
-    );
-  }
-
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -622,6 +585,7 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
 
   Widget _buildQuickCreateFab(ThemeHandler themeProvider) {
     return Column(
+      key: widget.tutorialTargets?.directoryCreateFabKey,
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
@@ -1060,7 +1024,8 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
     final foldersProvider =
         Provider.of<FoldersProvider>(context, listen: false);
     try {
-      await foldersProvider.updateFolder(newName, _currentFolder!.folderId, null);
+      await foldersProvider.updateFolder(
+          newName, _currentFolder!.folderId, null);
     } on ApiException catch (e) {
       if (mounted) {
         SnackBarDialog.showSnackBar(
@@ -1373,97 +1338,100 @@ class _DirectoryScreenState extends State<DirectoryScreen> {
 
   Widget _buildFolderAndProblemGrid(ThemeHandler themeProvider) {
     return Expanded(
+        key: widget.tutorialTargets?.folderListKey,
         child: Column(
-      children: [
-        Expanded(
-          child: Builder(
-            builder: (context) {
-              // 로컬 상태 사용 (Provider와 독립적)
-              var currentSubfolders = _localSubfolders;
-              var currentProblems = _localProblems;
-              final isLoadingMore = _isLoadingSubfolders || _isLoadingProblems;
+          children: [
+            Expanded(
+              child: Builder(
+                builder: (context) {
+                  // 로컬 상태 사용 (Provider와 독립적)
+                  var currentSubfolders = _localSubfolders;
+                  var currentProblems = _localProblems;
+                  final isLoadingMore =
+                      _isLoadingSubfolders || _isLoadingProblems;
 
-              // 초기 로딩 중이면 로딩 인디케이터 표시
-              if (_isInitialLoading) {
-                return const Center(
-                  child: CircularProgressIndicator(),
-                );
-              }
+                  // 초기 로딩 중이면 로딩 인디케이터 표시
+                  if (_isInitialLoading) {
+                    return const Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  }
 
-              // 로딩 완료 후에도 데이터가 없으면 빈 화면 표시
-              if (currentSubfolders.isEmpty && currentProblems.isEmpty) {
-                return SingleChildScrollView(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  child: SizedBox(
-                    height: MediaQuery.of(context).size.height * 0.7,
-                    child: Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          SvgPicture.asset(
-                            'assets/Icon/GreenNote.svg', // 아이콘 경로
-                            width: 100, // 적절한 크기 설정
-                            height: 100,
+                  // 로딩 완료 후에도 데이터가 없으면 빈 화면 표시
+                  if (currentSubfolders.isEmpty && currentProblems.isEmpty) {
+                    return SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: MediaQuery.of(context).size.height * 0.7,
+                        child: Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              SvgPicture.asset(
+                                'assets/Icon/GreenNote.svg', // 아이콘 경로
+                                width: 100, // 적절한 크기 설정
+                                height: 100,
+                              ),
+                              const SizedBox(height: 40), // 아이콘과 텍스트 사이 간격
+                              const StandardText(
+                                text: '작성한 오답노트를\n공책에 저장해 관리하세요!',
+                                fontSize: 16,
+                                color: Colors.black,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(
+                                height: 30,
+                              ),
+                              StandardText(
+                                text: '우측 하단 + 추가 버튼으로 새 오답노트를 작성할 수 있어요.',
+                                fontSize: 13,
+                                color: Colors.grey[600]!,
+                                textAlign: TextAlign.center,
+                              ),
+                            ],
                           ),
-                          const SizedBox(height: 40), // 아이콘과 텍스트 사이 간격
-                          const StandardText(
-                            text: '작성한 오답노트를\n공책에 저장해 관리하세요!',
-                            fontSize: 16,
-                            color: Colors.black,
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(
-                            height: 30,
-                          ),
-                          StandardText(
-                            text: '우측 하단 + 추가 버튼으로 새 오답노트를 작성할 수 있어요.',
-                            fontSize: 13,
-                            color: Colors.grey[600]!,
-                            textAlign: TextAlign.center,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                );
-              }
-
-              final totalItems =
-                  currentSubfolders.length + currentProblems.length;
-              final hasMore = _subfolderHasNext || _problemHasNext;
-
-              return ListView.builder(
-                controller: _scrollController,
-                physics: const AlwaysScrollableScrollPhysics(),
-                itemCount: totalItems + (isLoadingMore || hasMore ? 1 : 0),
-                itemBuilder: (context, index) {
-                  // 로딩 인디케이터 표시
-                  if (index == totalItems) {
-                    return const Padding(
-                      padding: EdgeInsets.all(16.0),
-                      child: Center(
-                        child: CircularProgressIndicator(),
+                        ),
                       ),
                     );
                   }
 
-                  if (index < currentSubfolders.length) {
-                    var subfolder = currentSubfolders[index];
-                    return _buildFolderTile(subfolder, themeProvider, index);
-                  } else {
-                    var problem =
-                        currentProblems[index - currentSubfolders.length];
-                    return _buildProblemTile(problem, themeProvider);
-                  }
+                  final totalItems =
+                      currentSubfolders.length + currentProblems.length;
+                  final hasMore = _subfolderHasNext || _problemHasNext;
+
+                  return ListView.builder(
+                    controller: _scrollController,
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    itemCount: totalItems + (isLoadingMore || hasMore ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      // 로딩 인디케이터 표시
+                      if (index == totalItems) {
+                        return const Padding(
+                          padding: EdgeInsets.all(16.0),
+                          child: Center(
+                            child: CircularProgressIndicator(),
+                          ),
+                        );
+                      }
+
+                      if (index < currentSubfolders.length) {
+                        var subfolder = currentSubfolders[index];
+                        return _buildFolderTile(
+                            subfolder, themeProvider, index);
+                      } else {
+                        var problem =
+                            currentProblems[index - currentSubfolders.length];
+                        return _buildProblemTile(problem, themeProvider);
+                      }
+                    },
+                  );
                 },
-              );
-            },
-          ),
-        ),
-        if (_isSelectionMode) _buildBottomActionButtons(themeProvider),
-      ],
-    ));
+              ),
+            ),
+            if (_isSelectionMode) _buildBottomActionButtons(themeProvider),
+          ],
+        ));
   }
 
   Widget _buildFolderTile(

--- a/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
+++ b/lib/Screen/PracticeNote/PracticeThumbnailScreen.dart
@@ -8,12 +8,18 @@ import '../../Model/PracticeNote/PracticeNoteThumbnailModel.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/PracticeNoteProvider.dart';
+import '../Tutorial/TutorialTargets.dart';
 import '../../Util/AppSnackBar.dart';
 import 'PracticeDetailScreen.dart';
 import 'PracticeProblemSelectionScreen.dart';
 
 class PracticeThumbnailScreen extends StatefulWidget {
-  const PracticeThumbnailScreen({super.key});
+  final TutorialTargets? tutorialTargets;
+
+  const PracticeThumbnailScreen({
+    super.key,
+    this.tutorialTargets,
+  });
 
   @override
   _ProblemPracticeScreen createState() => _ProblemPracticeScreen();
@@ -93,6 +99,7 @@ class _ProblemPracticeScreen extends State<PracticeThumbnailScreen> {
       floatingActionButton: _isSelectionMode
           ? null
           : SizedBox(
+              key: widget.tutorialTargets?.practiceCreateFabKey,
               height: 50,
               child: FloatingActionButton.extended(
                 heroTag: 'practice_create_fab',

--- a/lib/Screen/Tutorial/TutorialOverlay.dart
+++ b/lib/Screen/Tutorial/TutorialOverlay.dart
@@ -123,6 +123,8 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
             Container(color: Colors.black.withValues(alpha: 0.58)),
             if (tutorialProvider.isIntro)
               _buildIntroCard(tutorialProvider, themeProvider)
+            else if (tutorialProvider.isOutro)
+              _buildOutroCard(tutorialProvider, themeProvider)
             else
               _buildStepOverlay(tutorialProvider, themeProvider),
           ],
@@ -136,7 +138,14 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
     ThemeHandler themeProvider,
   ) {
     final mediaQuery = MediaQuery.of(context);
-    final maxWidth = mediaQuery.size.width >= 600 ? 420.0 : double.infinity;
+    final isTablet = mediaQuery.size.shortestSide >= 600;
+    final maxWidth = isTablet ? 560.0 : double.infinity;
+    final horizontalMargin = isTablet ? 32.0 : 24.0;
+    final cardPadding = isTablet ? 28.0 : 22.0;
+    final titleSize = isTablet ? 20.0 : 16.0;
+    final bodySize = isTablet ? 16.0 : 14.0;
+    final buttonSize = isTablet ? 15.0 : 14.0;
+    final frogSize = isTablet ? 116.0 : 86.0;
     final maxHeight = mediaQuery.size.height -
         mediaQuery.padding.top -
         mediaQuery.padding.bottom -
@@ -146,8 +155,8 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
       child: Center(
         child: Container(
           width: maxWidth,
-          margin: const EdgeInsets.symmetric(horizontal: 24),
-          padding: const EdgeInsets.all(22),
+          margin: EdgeInsets.symmetric(horizontal: horizontalMargin),
+          padding: EdgeInsets.all(cardPadding),
           decoration: BoxDecoration(
             color: Colors.white,
             borderRadius: BorderRadius.circular(18),
@@ -161,19 +170,20 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                 children: [
                   _buildFrogSpeech(
                     themeProvider: themeProvider,
+                    frogSize: frogSize,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const StandardText(
+                        StandardText(
                           text: 'OnO를 빠르게 둘러볼까요?',
-                          fontSize: 16,
+                          fontSize: titleSize,
                           color: Colors.black87,
                           fontWeight: FontWeight.w700,
                         ),
-                        const SizedBox(height: 10),
+                        const SizedBox(height: 14),
                         StandardText(
                           text: '공책, 오답노트, 복습 세트가 어떻게 연결되는지 짧게 안내해드릴게요.',
-                          fontSize: 14,
+                          fontSize: bodySize,
                           color: Colors.grey[700]!,
                           fontWeight: FontWeight.w500,
                           fontFamily: 'PretendardBold',
@@ -189,7 +199,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                         onPressed: tutorialProvider.skip,
                         child: StandardText(
                           text: '건너뛰기',
-                          fontSize: 14,
+                          fontSize: buttonSize,
                           color: Colors.grey[700]!,
                         ),
                       ),
@@ -203,9 +213,106 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                             borderRadius: BorderRadius.circular(8),
                           ),
                         ),
-                        child: const StandardText(
+                        child: StandardText(
                           text: '시작하기',
-                          fontSize: 14,
+                          fontSize: buttonSize,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOutroCard(
+    TutorialProvider tutorialProvider,
+    ThemeHandler themeProvider,
+  ) {
+    final mediaQuery = MediaQuery.of(context);
+    final isTablet = mediaQuery.size.shortestSide >= 600;
+    final maxWidth = isTablet ? 560.0 : double.infinity;
+    final horizontalMargin = isTablet ? 32.0 : 24.0;
+    final cardPadding = isTablet ? 28.0 : 22.0;
+    final frogSize = isTablet ? 116.0 : 86.0;
+    final titleSize = isTablet ? 22.0 : 18.0;
+    final bodySize = isTablet ? 16.0 : 14.0;
+    final buttonSize = isTablet ? 15.0 : 14.0;
+    final maxHeight = mediaQuery.size.height -
+        mediaQuery.padding.top -
+        mediaQuery.padding.bottom -
+        32;
+
+    return SafeArea(
+      child: Center(
+        child: Container(
+          width: maxWidth,
+          margin: EdgeInsets.symmetric(horizontal: horizontalMargin),
+          padding: EdgeInsets.all(cardPadding),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(18),
+          ),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: maxHeight),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildFrogSpeech(
+                    themeProvider: themeProvider,
+                    frogSize: frogSize,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        StandardText(
+                          text: '좋아요, 이제 OnO와 함께 시작해봐요!',
+                          fontSize: titleSize,
+                          color: Colors.black87,
+                          fontWeight: FontWeight.w700,
+                        ),
+                        const SizedBox(height: 14),
+                        StandardText(
+                          text:
+                              '공책에 오답을 모으고, 복습 세트로 다시 복습 하면서 100점을 향해 한 걸음씩 나아가요.',
+                          fontSize: bodySize,
+                          color: Colors.grey[700]!,
+                          fontWeight: FontWeight.w500,
+                          fontFamily: 'PretendardBold',
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 22),
+                  Row(
+                    children: [
+                      TextButton(
+                        onPressed: tutorialProvider.previous,
+                        child: StandardText(
+                          text: '이전',
+                          fontSize: buttonSize,
+                          color: Colors.grey[700]!,
+                        ),
+                      ),
+                      const Spacer(),
+                      ElevatedButton(
+                        onPressed: tutorialProvider.complete,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: themeProvider.primaryColor,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: StandardText(
+                          text: '완료',
+                          fontSize: buttonSize,
                           color: Colors.white,
                         ),
                       ),
@@ -229,22 +336,26 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
     final size = mediaQuery.size;
     final safeTop = mediaQuery.padding.top;
     final safeBottom = mediaQuery.padding.bottom;
-    final cardWidth = size.width >= 600 ? 420.0 : size.width - 32;
+    final isTablet = mediaQuery.size.shortestSide >= 600;
+    final cardWidth = isTablet ? 560.0 : size.width - 32;
     final cardLeft = size.width >= 600 ? (size.width - cardWidth) / 2 : 16.0;
     final cardMaxHeight = size.height - safeTop - safeBottom - 32;
+    final estimatedCardHeight = isTablet ? 310.0 : 230.0;
 
-    var cardTop = size.height - safeBottom - 250;
+    var cardTop = size.height - safeBottom - estimatedCardHeight - 20;
     if (rect != null) {
       final below = rect.bottom + 18;
-      final above = rect.top - 230;
-      if (below + 210 < size.height - safeBottom) {
+      final above = rect.top - estimatedCardHeight;
+      if (below + estimatedCardHeight < size.height - safeBottom) {
         cardTop = below;
       } else if (above > safeTop) {
         cardTop = above;
       }
     }
-    cardTop =
-        cardTop.clamp(safeTop + 12, size.height - safeBottom - 230).toDouble();
+    final minCardTop = safeTop + 12;
+    final maxCardTop = size.height - safeBottom - estimatedCardHeight;
+    final clampedMaxCardTop = maxCardTop < minCardTop ? minCardTop : maxCardTop;
+    cardTop = cardTop.clamp(minCardTop, clampedMaxCardTop).toDouble();
 
     return Stack(
       children: [
@@ -323,10 +434,19 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
     final step = tutorialProvider.currentStep;
     final isLast =
         tutorialProvider.currentStepIndex == tutorialSteps.length - 1;
+    final isTablet = MediaQuery.of(context).size.shortestSide >= 600;
+    final cardPadding = isTablet
+        ? const EdgeInsets.fromLTRB(22, 22, 22, 18)
+        : const EdgeInsets.fromLTRB(16, 16, 16, 14);
+    final frogSize = isTablet ? 104.0 : 76.0;
+    final progressSize = isTablet ? 13.0 : 11.0;
+    final titleSize = isTablet ? 20.0 : 16.0;
+    final bodySize = isTablet ? 16.0 : 14.0;
+    final buttonSize = isTablet ? 15.0 : 13.0;
 
     return Container(
       key: ValueKey(step.id),
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 14),
+      padding: cardPadding,
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
@@ -337,27 +457,27 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
         children: [
           _buildFrogSpeech(
             themeProvider: themeProvider,
-            frogSize: 76,
+            frogSize: frogSize,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 StandardText(
                   text:
                       '${tutorialProvider.currentStepIndex + 1} / ${tutorialSteps.length}',
-                  fontSize: 11,
+                  fontSize: progressSize,
                   color: themeProvider.primaryColor,
                 ),
-                const SizedBox(height: 8),
+                const SizedBox(height: 12),
                 StandardText(
                   text: step.title,
-                  fontSize: 16,
+                  fontSize: titleSize,
                   color: Colors.black87,
                   fontWeight: FontWeight.w700,
                 ),
                 const SizedBox(height: 8),
                 StandardText(
                   text: step.description,
-                  fontSize: 14,
+                  fontSize: bodySize,
                   color: Colors.grey[700]!,
                   fontWeight: FontWeight.w500,
                   fontFamily: 'PretendardBold',
@@ -372,7 +492,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                 onPressed: tutorialProvider.skip,
                 child: StandardText(
                   text: '건너뛰기',
-                  fontSize: 13,
+                  fontSize: buttonSize,
                   color: Colors.grey[700]!,
                 ),
               ),
@@ -382,7 +502,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                   onPressed: tutorialProvider.previous,
                   child: StandardText(
                     text: '이전',
-                    fontSize: 13,
+                    fontSize: buttonSize,
                     color: Colors.grey[700]!,
                   ),
                 ),
@@ -397,8 +517,8 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                   ),
                 ),
                 child: StandardText(
-                  text: isLast ? '완료' : '다음',
-                  fontSize: 13,
+                  text: '다음',
+                  fontSize: buttonSize,
                   color: Colors.white,
                 ),
               ),

--- a/lib/Screen/Tutorial/TutorialOverlay.dart
+++ b/lib/Screen/Tutorial/TutorialOverlay.dart
@@ -180,6 +180,9 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                     style: ElevatedButton.styleFrom(
                       backgroundColor: themeProvider.primaryColor,
                       foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
                     ),
                     child: const StandardText(
                       text: '시작하기',
@@ -351,6 +354,9 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                 style: ElevatedButton.styleFrom(
                   backgroundColor: themeProvider.primaryColor,
                   foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                 ),
                 child: StandardText(
                   text: isLast ? '완료' : '다음',

--- a/lib/Screen/Tutorial/TutorialOverlay.dart
+++ b/lib/Screen/Tutorial/TutorialOverlay.dart
@@ -27,6 +27,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
   static const Duration _motionDuration = Duration(milliseconds: 280);
   static const Curve _motionCurve = Curves.easeOutCubic;
   static const String _guideFrogAsset = 'assets/FrogCharacter/FROG_LEVEL15.png';
+  static const double _speechBorderWidth = 1.0;
 
   Rect? _targetRect;
   String? _lastStepId;
@@ -174,6 +175,8 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                           text: '공책, 오답노트, 복습 세트가 어떻게 연결되는지 짧게 안내해드릴게요.',
                           fontSize: 14,
                           color: Colors.grey[700]!,
+                          fontWeight: FontWeight.w500,
+                          fontFamily: 'PretendardBold',
                         ),
                       ],
                     ),
@@ -356,6 +359,8 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                   text: step.description,
                   fontSize: 14,
                   color: Colors.grey[700]!,
+                  fontWeight: FontWeight.w500,
+                  fontFamily: 'PretendardBold',
                 ),
               ],
             ),
@@ -410,11 +415,11 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
     double frogSize = 86,
   }) {
     final bubbleColor = Color.alphaBlend(
-      themeProvider.primaryColor.withValues(alpha: 0.16),
+      themeProvider.primaryColor.withValues(alpha: 0.08),
       Colors.white,
     );
     final bubbleBorderColor =
-        themeProvider.primaryColor.withValues(alpha: 0.14);
+        themeProvider.primaryColor.withValues(alpha: 0.20);
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -438,6 +443,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                   borderRadius: BorderRadius.circular(18),
                   border: Border.all(
                     color: bubbleBorderColor,
+                    width: _speechBorderWidth,
                   ),
                   boxShadow: [
                     BoxShadow(
@@ -450,12 +456,14 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                 child: child,
               ),
               Positioned(
-                left: -16,
+                left: -21,
                 top: 26,
                 child: CustomPaint(
-                  size: const Size(20, 24),
+                  size: const Size(23, 24),
                   painter: _SpeechTailPainter(
                     color: bubbleColor,
+                    borderColor: bubbleBorderColor,
+                    borderWidth: _speechBorderWidth,
                   ),
                 ),
               ),
@@ -469,25 +477,24 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
 
 class _SpeechTailPainter extends CustomPainter {
   final Color color;
+  final Color borderColor;
+  final double borderWidth;
 
   const _SpeechTailPainter({
     required this.color,
+    required this.borderColor,
+    required this.borderWidth,
   });
 
   @override
   void paint(Canvas canvas, Size size) {
+    final joinX = size.width;
+    final borderEndX = size.width - 1;
     final path = Path()
       ..moveTo(0, size.height / 2)
-      ..lineTo(size.width, 0)
-      ..lineTo(size.width, size.height)
+      ..lineTo(joinX, 0)
+      ..lineTo(joinX, size.height)
       ..close();
-
-    canvas.drawShadow(
-      path,
-      Colors.black.withValues(alpha: 0.08),
-      3,
-      false,
-    );
 
     canvas.drawPath(
       path,
@@ -495,10 +502,26 @@ class _SpeechTailPainter extends CustomPainter {
         ..color = color
         ..style = PaintingStyle.fill,
     );
+
+    final borderPaint = Paint()
+      ..color = borderColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = borderWidth
+      ..strokeCap = StrokeCap.butt
+      ..strokeJoin = StrokeJoin.round;
+
+    final borderPath = Path()
+      ..moveTo(0, size.height / 2)
+      ..lineTo(borderEndX, borderWidth / 2)
+      ..moveTo(0, size.height / 2)
+      ..lineTo(borderEndX, size.height - borderWidth / 2);
+    canvas.drawPath(borderPath, borderPaint);
   }
 
   @override
   bool shouldRepaint(covariant _SpeechTailPainter oldDelegate) {
-    return color != oldDelegate.color;
+    return color != oldDelegate.color ||
+        borderColor != oldDelegate.borderColor ||
+        borderWidth != oldDelegate.borderWidth;
   }
 }

--- a/lib/Screen/Tutorial/TutorialOverlay.dart
+++ b/lib/Screen/Tutorial/TutorialOverlay.dart
@@ -26,6 +26,7 @@ class TutorialOverlay extends StatefulWidget {
 class _TutorialOverlayState extends State<TutorialOverlay> {
   static const Duration _motionDuration = Duration(milliseconds: 280);
   static const Curve _motionCurve = Curves.easeOutCubic;
+  static const String _guideFrogAsset = 'assets/FrogCharacter/FROG_LEVEL15.png';
 
   Rect? _targetRect;
   String? _lastStepId;
@@ -135,6 +136,10 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
   ) {
     final mediaQuery = MediaQuery.of(context);
     final maxWidth = mediaQuery.size.width >= 600 ? 420.0 : double.infinity;
+    final maxHeight = mediaQuery.size.height -
+        mediaQuery.padding.top -
+        mediaQuery.padding.bottom -
+        32;
 
     return SafeArea(
       child: Center(
@@ -146,53 +151,66 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
             color: Colors.white,
             borderRadius: BorderRadius.circular(18),
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const StandardText(
-                text: 'OnO를 빠르게 둘러볼까요?',
-                fontSize: 20,
-                color: Colors.black87,
-                fontWeight: FontWeight.w700,
-              ),
-              const SizedBox(height: 12),
-              StandardText(
-                text: '공책, 오답노트, 복습 세트가 어떻게 연결되는지 짧게 안내해드릴게요.',
-                fontSize: 14,
-                color: Colors.grey[700]!,
-              ),
-              const SizedBox(height: 22),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: maxHeight),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  TextButton(
-                    onPressed: tutorialProvider.skip,
-                    child: StandardText(
-                      text: '건너뛰기',
-                      fontSize: 14,
-                      color: Colors.grey[700]!,
+                  _buildFrogSpeech(
+                    themeProvider: themeProvider,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const StandardText(
+                          text: 'OnO를 빠르게 둘러볼까요?',
+                          fontSize: 16,
+                          color: Colors.black87,
+                          fontWeight: FontWeight.w700,
+                        ),
+                        const SizedBox(height: 10),
+                        StandardText(
+                          text: '공책, 오답노트, 복습 세트가 어떻게 연결되는지 짧게 안내해드릴게요.',
+                          fontSize: 14,
+                          color: Colors.grey[700]!,
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(width: 8),
-                  ElevatedButton(
-                    onPressed: tutorialProvider.start,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: themeProvider.primaryColor,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
+                  const SizedBox(height: 22),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: tutorialProvider.skip,
+                        child: StandardText(
+                          text: '건너뛰기',
+                          fontSize: 14,
+                          color: Colors.grey[700]!,
+                        ),
                       ),
-                    ),
-                    child: const StandardText(
-                      text: '시작하기',
-                      fontSize: 14,
-                      color: Colors.white,
-                    ),
+                      const SizedBox(width: 8),
+                      ElevatedButton(
+                        onPressed: tutorialProvider.start,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: themeProvider.primaryColor,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: const StandardText(
+                          text: '시작하기',
+                          fontSize: 14,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),
-            ],
+            ),
           ),
         ),
       ),
@@ -210,6 +228,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
     final safeBottom = mediaQuery.padding.bottom;
     final cardWidth = size.width >= 600 ? 420.0 : size.width - 32;
     final cardLeft = size.width >= 600 ? (size.width - cardWidth) / 2 : 16.0;
+    final cardMaxHeight = size.height - safeTop - safeBottom - 32;
 
     var cardTop = size.height - safeBottom - 250;
     if (rect != null) {
@@ -266,23 +285,28 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
           left: cardLeft,
           top: cardTop,
           width: cardWidth,
-          child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 180),
-            switchInCurve: Curves.easeOut,
-            switchOutCurve: Curves.easeIn,
-            transitionBuilder: (child, animation) {
-              return FadeTransition(
-                opacity: animation,
-                child: SlideTransition(
-                  position: Tween<Offset>(
-                    begin: const Offset(0, 0.04),
-                    end: Offset.zero,
-                  ).animate(animation),
-                  child: child,
-                ),
-              );
-            },
-            child: _buildStepCard(tutorialProvider, themeProvider),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: cardMaxHeight),
+            child: SingleChildScrollView(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 180),
+                switchInCurve: Curves.easeOut,
+                switchOutCurve: Curves.easeIn,
+                transitionBuilder: (child, animation) {
+                  return FadeTransition(
+                    opacity: animation,
+                    child: SlideTransition(
+                      position: Tween<Offset>(
+                        begin: const Offset(0, 0.04),
+                        end: Offset.zero,
+                      ).animate(animation),
+                      child: child,
+                    ),
+                  );
+                },
+                child: _buildStepCard(tutorialProvider, themeProvider),
+              ),
+            ),
           ),
         ),
       ],
@@ -299,7 +323,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
 
     return Container(
       key: ValueKey(step.id),
-      padding: const EdgeInsets.all(18),
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 14),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
@@ -308,24 +332,33 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          StandardText(
-            text:
-                '${tutorialProvider.currentStepIndex + 1} / ${tutorialSteps.length}',
-            fontSize: 12,
-            color: themeProvider.primaryColor,
-          ),
-          const SizedBox(height: 8),
-          StandardText(
-            text: step.title,
-            fontSize: 18,
-            color: Colors.black87,
-            fontWeight: FontWeight.w700,
-          ),
-          const SizedBox(height: 8),
-          StandardText(
-            text: step.description,
-            fontSize: 14,
-            color: Colors.grey[700]!,
+          _buildFrogSpeech(
+            themeProvider: themeProvider,
+            frogSize: 76,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                StandardText(
+                  text:
+                      '${tutorialProvider.currentStepIndex + 1} / ${tutorialSteps.length}',
+                  fontSize: 11,
+                  color: themeProvider.primaryColor,
+                ),
+                const SizedBox(height: 8),
+                StandardText(
+                  text: step.title,
+                  fontSize: 16,
+                  color: Colors.black87,
+                  fontWeight: FontWeight.w700,
+                ),
+                const SizedBox(height: 8),
+                StandardText(
+                  text: step.description,
+                  fontSize: 14,
+                  color: Colors.grey[700]!,
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 18),
           Row(
@@ -369,5 +402,103 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
         ],
       ),
     );
+  }
+
+  Widget _buildFrogSpeech({
+    required ThemeHandler themeProvider,
+    required Widget child,
+    double frogSize = 86,
+  }) {
+    final bubbleColor = Color.alphaBlend(
+      themeProvider.primaryColor.withValues(alpha: 0.16),
+      Colors.white,
+    );
+    final bubbleBorderColor =
+        themeProvider.primaryColor.withValues(alpha: 0.14);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Image.asset(
+          _guideFrogAsset,
+          width: frogSize,
+          height: frogSize,
+          fit: BoxFit.contain,
+        ),
+        const SizedBox(width: 4),
+        Expanded(
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+                decoration: BoxDecoration(
+                  color: bubbleColor,
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(
+                    color: bubbleBorderColor,
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.06),
+                      blurRadius: 12,
+                      offset: const Offset(0, 3),
+                    ),
+                  ],
+                ),
+                child: child,
+              ),
+              Positioned(
+                left: -16,
+                top: 26,
+                child: CustomPaint(
+                  size: const Size(20, 24),
+                  painter: _SpeechTailPainter(
+                    color: bubbleColor,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SpeechTailPainter extends CustomPainter {
+  final Color color;
+
+  const _SpeechTailPainter({
+    required this.color,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = Path()
+      ..moveTo(0, size.height / 2)
+      ..lineTo(size.width, 0)
+      ..lineTo(size.width, size.height)
+      ..close();
+
+    canvas.drawShadow(
+      path,
+      Colors.black.withValues(alpha: 0.08),
+      3,
+      false,
+    );
+
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = color
+        ..style = PaintingStyle.fill,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _SpeechTailPainter oldDelegate) {
+    return color != oldDelegate.color;
   }
 }

--- a/lib/Screen/Tutorial/TutorialOverlay.dart
+++ b/lib/Screen/Tutorial/TutorialOverlay.dart
@@ -1,0 +1,367 @@
+// ignore_for_file: use_build_context_synchronously
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../Module/Text/StandardText.dart';
+import '../../Module/Theme/ThemeHandler.dart';
+import '../../Provider/TutorialProvider.dart';
+import 'TutorialStep.dart';
+import 'TutorialTargets.dart';
+
+class TutorialOverlay extends StatefulWidget {
+  final TutorialTargets targets;
+
+  const TutorialOverlay({
+    super.key,
+    required this.targets,
+  });
+
+  @override
+  State<TutorialOverlay> createState() => _TutorialOverlayState();
+}
+
+class _TutorialOverlayState extends State<TutorialOverlay> {
+  static const Duration _motionDuration = Duration(milliseconds: 280);
+  static const Curve _motionCurve = Curves.easeOutCubic;
+
+  Rect? _targetRect;
+  String? _lastStepId;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _syncStep();
+  }
+
+  @override
+  void didUpdateWidget(TutorialOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncStep();
+  }
+
+  void _syncStep() {
+    final tutorialProvider =
+        Provider.of<TutorialProvider>(context, listen: false);
+    if (!tutorialProvider.isRunning) return;
+
+    final step = tutorialProvider.currentStep;
+    if (_lastStepId == step.id) {
+      unawaited(_updateTargetRect());
+      return;
+    }
+
+    _lastStepId = step.id;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_updateTargetRect());
+    });
+  }
+
+  Future<void> _updateTargetRect() async {
+    final tutorialProvider =
+        Provider.of<TutorialProvider>(context, listen: false);
+    if (!tutorialProvider.isRunning) return;
+
+    final targetKey =
+        tutorialProvider.currentStep.targetType.resolve(widget.targets);
+
+    for (var attempt = 0; attempt < 4; attempt++) {
+      final targetContext = targetKey.currentContext;
+      if (targetContext != null) {
+        unawaited(Scrollable.ensureVisible(
+          targetContext,
+          duration: _motionDuration,
+          curve: _motionCurve,
+          alignment: 0.35,
+        ));
+        await Future<void>.delayed(_motionDuration);
+        if (!mounted) return;
+        final updatedTargetContext = targetKey.currentContext;
+        final renderObject = updatedTargetContext?.findRenderObject();
+        if (renderObject is RenderBox && renderObject.hasSize) {
+          final offset = renderObject.localToGlobal(Offset.zero);
+          setState(() {
+            _targetRect = offset & renderObject.size;
+          });
+          return;
+        }
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+    }
+
+    if (mounted) {
+      setState(() {
+        _targetRect = null;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tutorialProvider = Provider.of<TutorialProvider>(context);
+    if (!tutorialProvider.isVisible) {
+      _lastStepId = null;
+      return const SizedBox.shrink();
+    }
+
+    if (tutorialProvider.isRunning) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _syncStep());
+    }
+
+    final themeProvider = Provider.of<ThemeHandler>(context);
+
+    return Positioned.fill(
+      child: Material(
+        color: Colors.transparent,
+        child: Stack(
+          children: [
+            Container(color: Colors.black.withValues(alpha: 0.58)),
+            if (tutorialProvider.isIntro)
+              _buildIntroCard(tutorialProvider, themeProvider)
+            else
+              _buildStepOverlay(tutorialProvider, themeProvider),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIntroCard(
+    TutorialProvider tutorialProvider,
+    ThemeHandler themeProvider,
+  ) {
+    final mediaQuery = MediaQuery.of(context);
+    final maxWidth = mediaQuery.size.width >= 600 ? 420.0 : double.infinity;
+
+    return SafeArea(
+      child: Center(
+        child: Container(
+          width: maxWidth,
+          margin: const EdgeInsets.symmetric(horizontal: 24),
+          padding: const EdgeInsets.all(22),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(18),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const StandardText(
+                text: 'OnO를 빠르게 둘러볼까요?',
+                fontSize: 20,
+                color: Colors.black87,
+                fontWeight: FontWeight.w700,
+              ),
+              const SizedBox(height: 12),
+              StandardText(
+                text: '공책, 오답노트, 복습 세트가 어떻게 연결되는지 짧게 안내해드릴게요.',
+                fontSize: 14,
+                color: Colors.grey[700]!,
+              ),
+              const SizedBox(height: 22),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: tutorialProvider.skip,
+                    child: StandardText(
+                      text: '건너뛰기',
+                      fontSize: 14,
+                      color: Colors.grey[700]!,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: tutorialProvider.start,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: themeProvider.primaryColor,
+                      foregroundColor: Colors.white,
+                    ),
+                    child: const StandardText(
+                      text: '시작하기',
+                      fontSize: 14,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStepOverlay(
+    TutorialProvider tutorialProvider,
+    ThemeHandler themeProvider,
+  ) {
+    final rect = _targetRect;
+    final mediaQuery = MediaQuery.of(context);
+    final size = mediaQuery.size;
+    final safeTop = mediaQuery.padding.top;
+    final safeBottom = mediaQuery.padding.bottom;
+    final cardWidth = size.width >= 600 ? 420.0 : size.width - 32;
+    final cardLeft = size.width >= 600 ? (size.width - cardWidth) / 2 : 16.0;
+
+    var cardTop = size.height - safeBottom - 250;
+    if (rect != null) {
+      final below = rect.bottom + 18;
+      final above = rect.top - 230;
+      if (below + 210 < size.height - safeBottom) {
+        cardTop = below;
+      } else if (above > safeTop) {
+        cardTop = above;
+      }
+    }
+    cardTop =
+        cardTop.clamp(safeTop + 12, size.height - safeBottom - 230).toDouble();
+
+    return Stack(
+      children: [
+        if (rect != null)
+          AnimatedPositioned(
+            duration: _motionDuration,
+            curve: _motionCurve,
+            left: (rect.left - 8).clamp(8.0, size.width - 24).toDouble(),
+            top: (rect.top - 8).clamp(safeTop + 8, size.height - 24).toDouble(),
+            width: (rect.width + 16).clamp(24.0, size.width - 16).toDouble(),
+            height: (rect.height + 16)
+                .clamp(24.0, size.height - safeTop - 16)
+                .toDouble(),
+            child: IgnorePointer(
+              child: AnimatedOpacity(
+                duration: _motionDuration,
+                curve: _motionCurve,
+                opacity: 1,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(18),
+                    border: Border.all(
+                      color: themeProvider.primaryColor,
+                      width: 3,
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color:
+                            themeProvider.primaryColor.withValues(alpha: 0.35),
+                        blurRadius: 18,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        AnimatedPositioned(
+          duration: _motionDuration,
+          curve: _motionCurve,
+          left: cardLeft,
+          top: cardTop,
+          width: cardWidth,
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 180),
+            switchInCurve: Curves.easeOut,
+            switchOutCurve: Curves.easeIn,
+            transitionBuilder: (child, animation) {
+              return FadeTransition(
+                opacity: animation,
+                child: SlideTransition(
+                  position: Tween<Offset>(
+                    begin: const Offset(0, 0.04),
+                    end: Offset.zero,
+                  ).animate(animation),
+                  child: child,
+                ),
+              );
+            },
+            child: _buildStepCard(tutorialProvider, themeProvider),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStepCard(
+    TutorialProvider tutorialProvider,
+    ThemeHandler themeProvider,
+  ) {
+    final step = tutorialProvider.currentStep;
+    final isLast =
+        tutorialProvider.currentStepIndex == tutorialSteps.length - 1;
+
+    return Container(
+      key: ValueKey(step.id),
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          StandardText(
+            text:
+                '${tutorialProvider.currentStepIndex + 1} / ${tutorialSteps.length}',
+            fontSize: 12,
+            color: themeProvider.primaryColor,
+          ),
+          const SizedBox(height: 8),
+          StandardText(
+            text: step.title,
+            fontSize: 18,
+            color: Colors.black87,
+            fontWeight: FontWeight.w700,
+          ),
+          const SizedBox(height: 8),
+          StandardText(
+            text: step.description,
+            fontSize: 14,
+            color: Colors.grey[700]!,
+          ),
+          const SizedBox(height: 18),
+          Row(
+            children: [
+              TextButton(
+                onPressed: tutorialProvider.skip,
+                child: StandardText(
+                  text: '건너뛰기',
+                  fontSize: 13,
+                  color: Colors.grey[700]!,
+                ),
+              ),
+              const Spacer(),
+              if (tutorialProvider.currentStepIndex > 0)
+                TextButton(
+                  onPressed: tutorialProvider.previous,
+                  child: StandardText(
+                    text: '이전',
+                    fontSize: 13,
+                    color: Colors.grey[700]!,
+                  ),
+                ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: tutorialProvider.next,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: themeProvider.primaryColor,
+                  foregroundColor: Colors.white,
+                ),
+                child: StandardText(
+                  text: isLast ? '완료' : '다음',
+                  fontSize: 13,
+                  color: Colors.white,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/Screen/Tutorial/TutorialOverlay.dart
+++ b/lib/Screen/Tutorial/TutorialOverlay.dart
@@ -142,9 +142,9 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
     final maxWidth = isTablet ? 560.0 : double.infinity;
     final horizontalMargin = isTablet ? 32.0 : 24.0;
     final cardPadding = isTablet ? 28.0 : 22.0;
-    final titleSize = isTablet ? 20.0 : 16.0;
-    final bodySize = isTablet ? 16.0 : 14.0;
-    final buttonSize = isTablet ? 15.0 : 14.0;
+    final titleSize = isTablet ? 18.0 : 14.0;
+    final bodySize = isTablet ? 14.0 : 12.0;
+    final buttonSize = isTablet ? 14.0 : 13.0;
     final frogSize = isTablet ? 116.0 : 86.0;
     final maxHeight = mediaQuery.size.height -
         mediaQuery.padding.top -
@@ -182,7 +182,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                         ),
                         const SizedBox(height: 14),
                         StandardText(
-                          text: '공책, 오답노트, 복습 세트가 어떻게 연결되는지 짧게 안내해드릴게요.',
+                          text: '공책, 오답노트, 복습 세트가\n어떻게 연결되는지 짧게 안내해드릴게요.',
                           fontSize: bodySize,
                           color: Colors.grey[700]!,
                           fontWeight: FontWeight.w500,
@@ -239,10 +239,10 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
     final maxWidth = isTablet ? 560.0 : double.infinity;
     final horizontalMargin = isTablet ? 32.0 : 24.0;
     final cardPadding = isTablet ? 28.0 : 22.0;
-    final frogSize = isTablet ? 116.0 : 86.0;
-    final titleSize = isTablet ? 22.0 : 18.0;
-    final bodySize = isTablet ? 16.0 : 14.0;
-    final buttonSize = isTablet ? 15.0 : 14.0;
+    final frogSize = isTablet ? 104.0 : 76.0;
+    final titleSize = isTablet ? 18.0 : 14.0;
+    final bodySize = isTablet ? 14.0 : 12.0;
+    final buttonSize = isTablet ? 14.0 : 13.0;
     final maxHeight = mediaQuery.size.height -
         mediaQuery.padding.top -
         mediaQuery.padding.bottom -
@@ -280,7 +280,7 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
                         const SizedBox(height: 14),
                         StandardText(
                           text:
-                              '공책에 오답을 모으고, 복습 세트로 다시 복습 하면서 100점을 향해 한 걸음씩 나아가요.',
+                              '공책에 오답을 모으고, 복습 세트로 다시 복습하면서 100점을 향해 한 걸음씩 나아가요!',
                           fontSize: bodySize,
                           color: Colors.grey[700]!,
                           fontWeight: FontWeight.w500,
@@ -439,10 +439,10 @@ class _TutorialOverlayState extends State<TutorialOverlay> {
         ? const EdgeInsets.fromLTRB(22, 22, 22, 18)
         : const EdgeInsets.fromLTRB(16, 16, 16, 14);
     final frogSize = isTablet ? 104.0 : 76.0;
-    final progressSize = isTablet ? 13.0 : 11.0;
-    final titleSize = isTablet ? 20.0 : 16.0;
-    final bodySize = isTablet ? 16.0 : 14.0;
-    final buttonSize = isTablet ? 15.0 : 13.0;
+    final progressSize = isTablet ? 11.0 : 10.0;
+    final titleSize = isTablet ? 18.0 : 14.0;
+    final bodySize = isTablet ? 14.0 : 12.0;
+    final buttonSize = isTablet ? 14.0 : 12.0;
 
     return Container(
       key: ValueKey(step.id),

--- a/lib/Screen/Tutorial/TutorialStep.dart
+++ b/lib/Screen/Tutorial/TutorialStep.dart
@@ -11,6 +11,7 @@ enum TutorialStatus {
   idle,
   intro,
   running,
+  outro,
 }
 
 enum TutorialTargetType {
@@ -82,7 +83,7 @@ const List<TutorialStep> tutorialSteps = [
     tabIndex: 2,
     targetType: TutorialTargetType.reportCard,
     title: '복습 리포트',
-    description: '복습 추이와 약점을 확인하고, 설정에서는 테마 변경과 튜토리얼 다시 보기를 할 수 있어요.',
+    description: '복습 추이와 약점을 확인하면 어떤 부분을 더 공부해야 할지 쉽게 알 수 있어요.',
   ),
 ];
 

--- a/lib/Screen/Tutorial/TutorialStep.dart
+++ b/lib/Screen/Tutorial/TutorialStep.dart
@@ -47,7 +47,7 @@ const List<TutorialStep> tutorialSteps = [
     tabIndex: 0,
     targetType: TutorialTargetType.folderList,
     title: '공책과 오답노트',
-    description: '공책은 오답노트를 담는 폴더예요. 과목이나 시험 범위별로 나눠 관리할 수 있어요.',
+    description: '공책은 오답노트를 담는 폴더예요.\n과목이나 시험 범위별로 나눠 관리할 수 있어요.',
   ),
   TutorialStep(
     id: 'create_problem_note',
@@ -55,35 +55,35 @@ const List<TutorialStep> tutorialSteps = [
     targetType: TutorialTargetType.directoryCreateFab,
     title: '오답노트 작성 시작',
     description:
-        '+ 추가 버튼에서 공책을 만들거나 오답노트를 작성할 수 있어요. 여러 장 작성으로 이미지를 한 번에 등록할 수도 있어요.',
+        '+ 추가 버튼에서 공책을 만들거나 오답노트를 작성할 수 있어요.\n여러 장 작성으로 이미지를 한 번에 등록할 수도 있어요.',
   ),
   TutorialStep(
     id: 'practice_set',
     tabIndex: 1,
     targetType: TutorialTargetType.practiceCreateFab,
     title: '복습 세트',
-    description: '복습 세트는 여러 오답노트를 묶어 다시 푸는 공간이에요. 시험 전에 필요한 문제만 골라 반복할 수 있어요.',
+    description: '복습 세트는 여러 오답노트를 묶어 다시 푸는 공간이에요.\n시험 전에 필요한 문제만 골라 반복할 수 있어요.',
   ),
   TutorialStep(
     id: 'level',
     tabIndex: 2,
     targetType: TutorialTargetType.levelCard,
     title: '레벨과 성장',
-    description: '출석, 오답노트 작성, 문제 복습이 쌓이면 레벨과 포인트가 올라요.',
+    description: '출석, 오답노트 작성, 문제 복습이 쌓이면\n레벨과 포인트가 올라요.',
   ),
   TutorialStep(
     id: 'calendar',
     tabIndex: 2,
     targetType: TutorialTargetType.calendarCard,
     title: '학습 달력',
-    description: '공부한 날과 복습 기록을 달력에서 확인해요. 며칠 동안 꾸준히 공부했는지도 볼 수 있어요.',
+    description: '공부한 날과 복습 기록을 달력에서 확인해요.\n며칠 동안 꾸준히 공부했는지도 볼 수 있어요.',
   ),
   TutorialStep(
     id: 'report',
     tabIndex: 2,
     targetType: TutorialTargetType.reportCard,
     title: '복습 리포트',
-    description: '복습 추이와 약점을 확인하면 어떤 부분을 더 공부해야 할지 쉽게 알 수 있어요.',
+    description: '복습 추이와 약점을 확인하면\n어떤 부분을 더 공부해야 할지 쉽게 알 수 있어요.',
   ),
 ];
 

--- a/lib/Screen/Tutorial/TutorialStep.dart
+++ b/lib/Screen/Tutorial/TutorialStep.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import 'TutorialTargets.dart';
+
+enum TutorialLaunchSource {
+  firstSignup,
+  settingsReplay,
+}
+
+enum TutorialStatus {
+  idle,
+  intro,
+  running,
+}
+
+enum TutorialTargetType {
+  folderList,
+  directoryCreateFab,
+  practiceCreateFab,
+  levelCard,
+  calendarCard,
+  reportCard,
+}
+
+class TutorialStep {
+  final String id;
+  final int tabIndex;
+  final TutorialTargetType targetType;
+  final String title;
+  final String description;
+
+  const TutorialStep({
+    required this.id,
+    required this.tabIndex,
+    required this.targetType,
+    required this.title,
+    required this.description,
+  });
+}
+
+const int currentTutorialVersion = 1;
+
+const List<TutorialStep> tutorialSteps = [
+  TutorialStep(
+    id: 'folder_unit',
+    tabIndex: 0,
+    targetType: TutorialTargetType.folderList,
+    title: '공책과 오답노트',
+    description: '공책은 오답노트를 담는 폴더예요. 과목이나 시험 범위별로 나눠 관리할 수 있어요.',
+  ),
+  TutorialStep(
+    id: 'create_problem_note',
+    tabIndex: 0,
+    targetType: TutorialTargetType.directoryCreateFab,
+    title: '오답노트 작성 시작',
+    description:
+        '+ 추가 버튼에서 공책을 만들거나 오답노트를 작성할 수 있어요. 여러 장 작성으로 이미지를 한 번에 등록할 수도 있어요.',
+  ),
+  TutorialStep(
+    id: 'practice_set',
+    tabIndex: 1,
+    targetType: TutorialTargetType.practiceCreateFab,
+    title: '복습 세트',
+    description: '복습 세트는 여러 오답노트를 묶어 다시 푸는 공간이에요. 시험 전에 필요한 문제만 골라 반복할 수 있어요.',
+  ),
+  TutorialStep(
+    id: 'level',
+    tabIndex: 2,
+    targetType: TutorialTargetType.levelCard,
+    title: '레벨과 성장',
+    description: '출석, 오답노트 작성, 문제 복습이 쌓이면 레벨과 포인트가 올라요.',
+  ),
+  TutorialStep(
+    id: 'calendar',
+    tabIndex: 2,
+    targetType: TutorialTargetType.calendarCard,
+    title: '학습 달력',
+    description: '공부한 날과 복습 기록을 달력에서 확인해요. 며칠 동안 꾸준히 공부했는지도 볼 수 있어요.',
+  ),
+  TutorialStep(
+    id: 'report',
+    tabIndex: 2,
+    targetType: TutorialTargetType.reportCard,
+    title: '복습 리포트',
+    description: '복습 추이와 약점을 확인하고, 설정에서는 테마 변경과 튜토리얼 다시 보기를 할 수 있어요.',
+  ),
+];
+
+extension TutorialTargetResolver on TutorialTargetType {
+  GlobalKey resolve(TutorialTargets targets) {
+    switch (this) {
+      case TutorialTargetType.folderList:
+        return targets.folderListKey;
+      case TutorialTargetType.directoryCreateFab:
+        return targets.directoryCreateFabKey;
+      case TutorialTargetType.practiceCreateFab:
+        return targets.practiceCreateFabKey;
+      case TutorialTargetType.levelCard:
+        return targets.levelCardKey;
+      case TutorialTargetType.calendarCard:
+        return targets.calendarCardKey;
+      case TutorialTargetType.reportCard:
+        return targets.reportCardKey;
+    }
+  }
+}

--- a/lib/Screen/Tutorial/TutorialStorage.dart
+++ b/lib/Screen/Tutorial/TutorialStorage.dart
@@ -1,0 +1,18 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'TutorialStep.dart';
+
+class TutorialStorage {
+  static String _completedKey(int userId) =>
+      'tutorial_completed_user_${userId}_v$currentTutorialVersion';
+
+  Future<bool> isCompleted(int userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_completedKey(userId)) ?? false;
+  }
+
+  Future<void> markCompleted(int userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_completedKey(userId), true);
+  }
+}

--- a/lib/Screen/Tutorial/TutorialTargets.dart
+++ b/lib/Screen/Tutorial/TutorialTargets.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class TutorialTargets {
+  final GlobalKey folderListKey = GlobalKey();
+  final GlobalKey directoryCreateFabKey = GlobalKey();
+  final GlobalKey practiceCreateFabKey = GlobalKey();
+  final GlobalKey levelCardKey = GlobalKey();
+  final GlobalKey calendarCardKey = GlobalKey();
+  final GlobalKey reportCardKey = GlobalKey();
+}

--- a/lib/Screen/User/MyPageScreen.dart
+++ b/lib/Screen/User/MyPageScreen.dart
@@ -10,7 +10,9 @@ import '../../Module/Dialog/ThemeDialog.dart';
 import '../../Module/Text/StandardText.dart';
 import '../../Module/Theme/ThemeHandler.dart';
 import '../../Provider/ScreenIndexProvider.dart';
+import '../../Provider/TutorialProvider.dart';
 import '../../Provider/UserProvider.dart';
+import '../Tutorial/TutorialTargets.dart';
 import 'LoginScreen.dart';
 import 'Widget/AccountActionButtons.dart';
 import 'Widget/ReviewReportScreen.dart';
@@ -20,7 +22,12 @@ import 'Widget/StreakCard.dart';
 import 'Widget/UserLevelCard.dart';
 
 class SettingScreen extends StatefulWidget {
-  const SettingScreen({super.key});
+  final TutorialTargets? tutorialTargets;
+
+  const SettingScreen({
+    super.key,
+    this.tutorialTargets,
+  });
 
   @override
   _SettingScreenState createState() => _SettingScreenState();
@@ -88,6 +95,7 @@ class _SettingScreenState extends State<SettingScreen> {
                           children: [
                             Expanded(
                               child: UserLevelCard(
+                                key: widget.tutorialTargets?.levelCardKey,
                                 userInfo: userProvider.userInfoModel,
                                 themeProvider: themeProvider,
                                 userName:
@@ -98,6 +106,7 @@ class _SettingScreenState extends State<SettingScreen> {
                             SizedBox(width: screenWidth * 0.02),
                             Expanded(
                               child: StreakCard(
+                                key: widget.tutorialTargets?.calendarCardKey,
                                 themeProvider: themeProvider,
                                 horizontalMarginFactor: 0,
                               ),
@@ -108,6 +117,7 @@ class _SettingScreenState extends State<SettingScreen> {
                     )
                   else ...[
                     UserLevelCard(
+                      key: widget.tutorialTargets?.levelCardKey,
                       userInfo: userProvider.userInfoModel,
                       themeProvider: themeProvider,
                       userName: userProvider.userInfoModel?.name ?? '이름 없음',
@@ -115,7 +125,10 @@ class _SettingScreenState extends State<SettingScreen> {
                   ],
                   if (!isTabletLandscape) ...[
                     SizedBox(height: screenHeight * 0.01),
-                    StreakCard(themeProvider: themeProvider),
+                    StreakCard(
+                      key: widget.tutorialTargets?.calendarCardKey,
+                      themeProvider: themeProvider,
+                    ),
                   ],
                   SizedBox(height: screenHeight * 0.01),
                   _buildReviewReportButton(themeProvider),
@@ -153,6 +166,7 @@ class _SettingScreenState extends State<SettingScreen> {
     const dummyLabels = ['월', '화', '수', '목', '금', '토', '일'];
 
     return Container(
+      key: widget.tutorialTargets?.reportCardKey,
       margin: EdgeInsets.symmetric(
         horizontal: screenWidth * horizontalMarginFactor,
         vertical: screenHeight * 0.005,
@@ -234,7 +248,10 @@ class _SettingScreenState extends State<SettingScreen> {
                   ),
                 ],
               ),
-              SizedBox(height: isTabletLandscape ? screenHeight * 0.024 : screenHeight * 0.014),
+              SizedBox(
+                  height: isTabletLandscape
+                      ? screenHeight * 0.024
+                      : screenHeight * 0.014),
               _buildMosaicTrendPreview(
                 themeProvider,
                 dummyBars,
@@ -430,6 +447,17 @@ class _MyPageSettingsScreen extends StatelessWidget {
                   },
                   onGuideTap: () {
                     UrlLauncher.launchGuidePageURL();
+                  },
+                  onTutorialReplayTap: () {
+                    final userId = userProvider.userInfoModel?.userId;
+                    if (userId == null) return;
+                    final tutorialProvider =
+                        Provider.of<TutorialProvider>(context, listen: false);
+                    FirebaseAnalytics.instance
+                        .logEvent(name: 'tutorial_replay_button_click');
+                    Navigator.of(context).pop();
+                    screenIndexProvider.setSelectedIndex(0);
+                    tutorialProvider.showReplayIntro(userId);
                   },
                   onFeedbackTap: () {
                     UrlLauncher.launchFeedbackPageURL();

--- a/lib/Screen/User/MyPageScreen.dart
+++ b/lib/Screen/User/MyPageScreen.dart
@@ -435,6 +435,22 @@ class _MyPageSettingsScreen extends StatelessWidget {
                   },
                 ),
                 const SizedBox(height: 8),
+                _buildTutorialReplaySection(
+                  context: context,
+                  themeProvider: themeProvider,
+                  onTap: () {
+                    final userId = userProvider.userInfoModel?.userId;
+                    if (userId == null) return;
+                    final tutorialProvider =
+                        Provider.of<TutorialProvider>(context, listen: false);
+                    FirebaseAnalytics.instance
+                        .logEvent(name: 'tutorial_replay_button_click');
+                    Navigator.of(context).pop();
+                    screenIndexProvider.setSelectedIndex(0);
+                    tutorialProvider.showReplayIntro(userId);
+                  },
+                ),
+                const SizedBox(height: 8),
                 SettingMenuButtons(
                   themeProvider: themeProvider,
                   onNameEditTap: () {
@@ -447,17 +463,6 @@ class _MyPageSettingsScreen extends StatelessWidget {
                   },
                   onGuideTap: () {
                     UrlLauncher.launchGuidePageURL();
-                  },
-                  onTutorialReplayTap: () {
-                    final userId = userProvider.userInfoModel?.userId;
-                    if (userId == null) return;
-                    final tutorialProvider =
-                        Provider.of<TutorialProvider>(context, listen: false);
-                    FirebaseAnalytics.instance
-                        .logEvent(name: 'tutorial_replay_button_click');
-                    Navigator.of(context).pop();
-                    screenIndexProvider.setSelectedIndex(0);
-                    tutorialProvider.showReplayIntro(userId);
                   },
                   onFeedbackTap: () {
                     UrlLauncher.launchFeedbackPageURL();
@@ -530,6 +535,75 @@ class _MyPageSettingsScreen extends StatelessWidget {
       ),
     );
   }
+}
+
+Widget _buildTutorialReplaySection({
+  required BuildContext context,
+  required ThemeHandler themeProvider,
+  required VoidCallback onTap,
+}) {
+  final mediaQuery = MediaQuery.of(context);
+  final screenHeight = mediaQuery.size.height;
+  final screenWidth = mediaQuery.size.width;
+
+  return Container(
+    margin: EdgeInsets.symmetric(
+      horizontal: screenWidth * 0.04,
+      vertical: screenHeight * 0.01,
+    ),
+    padding: EdgeInsets.all(screenHeight * 0.015),
+    decoration: BoxDecoration(
+      color: Colors.grey[50],
+      borderRadius: BorderRadius.circular(15),
+      border: Border.all(
+        color: Colors.grey[300]!,
+        width: 1,
+      ),
+    ),
+    child: InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          vertical: screenHeight * 0.008,
+          horizontal: screenHeight * 0.01,
+        ),
+        child: Row(
+          children: [
+            Icon(
+              Icons.school_outlined,
+              size: 20,
+              color: themeProvider.primaryColor,
+            ),
+            SizedBox(width: screenHeight * 0.015),
+            const Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  StandardText(
+                    text: '튜토리얼 다시 보기',
+                    fontSize: 14,
+                    color: Colors.black87,
+                  ),
+                  SizedBox(height: 3),
+                  StandardText(
+                    text: 'OnO 사용법을 처음부터 다시 둘러봐요',
+                    fontSize: 11,
+                    color: Colors.grey,
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              size: 20,
+              color: Colors.grey[400],
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
 }
 
 void _showChangeNameDialog(BuildContext context, String currentName) {

--- a/lib/Screen/User/Widget/SettingMenuButtons.dart
+++ b/lib/Screen/User/Widget/SettingMenuButtons.dart
@@ -6,7 +6,6 @@ class SettingMenuButtons extends StatelessWidget {
   final ThemeHandler themeProvider;
   final VoidCallback onNameEditTap;
   final VoidCallback onGuideTap;
-  final VoidCallback onTutorialReplayTap;
   final VoidCallback onFeedbackTap;
   final VoidCallback onTermsTap;
   final bool notificationEnabled;
@@ -17,7 +16,6 @@ class SettingMenuButtons extends StatelessWidget {
     required this.themeProvider,
     required this.onNameEditTap,
     required this.onGuideTap,
-    required this.onTutorialReplayTap,
     required this.onFeedbackTap,
     required this.onTermsTap,
     required this.notificationEnabled,
@@ -58,13 +56,6 @@ class SettingMenuButtons extends StatelessWidget {
             icon: Icons.edit,
             title: '이름 수정',
             onTap: onNameEditTap,
-          ),
-          Divider(height: screenHeight * 0.02, color: Colors.grey[300]),
-          _buildMenuItem(
-            context: context,
-            icon: Icons.school_outlined,
-            title: '튜토리얼 다시 보기',
-            onTap: onTutorialReplayTap,
           ),
           Divider(height: screenHeight * 0.02, color: Colors.grey[300]),
           _buildMenuItem(

--- a/lib/Screen/User/Widget/SettingMenuButtons.dart
+++ b/lib/Screen/User/Widget/SettingMenuButtons.dart
@@ -6,6 +6,7 @@ class SettingMenuButtons extends StatelessWidget {
   final ThemeHandler themeProvider;
   final VoidCallback onNameEditTap;
   final VoidCallback onGuideTap;
+  final VoidCallback onTutorialReplayTap;
   final VoidCallback onFeedbackTap;
   final VoidCallback onTermsTap;
   final bool notificationEnabled;
@@ -16,6 +17,7 @@ class SettingMenuButtons extends StatelessWidget {
     required this.themeProvider,
     required this.onNameEditTap,
     required this.onGuideTap,
+    required this.onTutorialReplayTap,
     required this.onFeedbackTap,
     required this.onTermsTap,
     required this.notificationEnabled,
@@ -56,6 +58,13 @@ class SettingMenuButtons extends StatelessWidget {
             icon: Icons.edit,
             title: '이름 수정',
             onTap: onNameEditTap,
+          ),
+          Divider(height: screenHeight * 0.02, color: Colors.grey[300]),
+          _buildMenuItem(
+            context: context,
+            icon: Icons.school_outlined,
+            title: '튜토리얼 다시 보기',
+            onTap: onTutorialReplayTap,
           ),
           Divider(height: screenHeight * 0.02, color: Colors.grey[300]),
           _buildMenuItem(
@@ -113,7 +122,8 @@ class SettingMenuButtons extends StatelessWidget {
             child: Switch(
               value: value,
               activeThumbColor: themeProvider.primaryColor,
-              activeTrackColor: themeProvider.primaryColor.withValues(alpha: 0.5),
+              activeTrackColor:
+                  themeProvider.primaryColor.withValues(alpha: 0.5),
               inactiveTrackColor: Colors.grey.shade300,
               inactiveThumbColor: Colors.grey,
               materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,8 +23,11 @@ import 'Provider/PracticeNoteProvider.dart';
 import 'Provider/ProblemsProvider.dart';
 import 'Provider/ReviewDueProvider.dart';
 import 'Provider/UserProvider.dart';
+import 'Provider/TutorialProvider.dart';
 import 'Screen/Folder/DirectoryScreen.dart';
 import 'Screen/PracticeNote/PracticeThumbnailScreen.dart';
+import 'Screen/Tutorial/TutorialOverlay.dart';
+import 'Screen/Tutorial/TutorialTargets.dart';
 import 'Screen/User/MyPageScreen.dart';
 import 'Util/AppErrorReporter.dart';
 import 'Util/AppNavigator.dart';
@@ -133,6 +136,7 @@ Future<void> _bootstrapApp() async {
         ),
         ChangeNotifierProvider(create: (_) => ScreenIndexProvider()),
         ChangeNotifierProvider(create: (_) => ReviewDueProvider()),
+        ChangeNotifierProvider(create: (_) => TutorialProvider()),
       ],
       child: const MyApp(),
     ),
@@ -203,16 +207,17 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
-  static const List<Widget> _widgetOptions = <Widget>[
-    DirectoryScreen(),
-    PracticeThumbnailScreen(),
-    SettingScreen(),
-  ];
+  final TutorialTargets _tutorialTargets = TutorialTargets();
+  bool _didPrepareTutorial = false;
+  int? _lastSyncedTutorialStepIndex;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _prepareInitialTutorial();
+    });
   }
 
   @override
@@ -228,6 +233,20 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
     ).setSelectedIndex(index);
   }
 
+  Future<void> _prepareInitialTutorial() async {
+    if (_didPrepareTutorial || !mounted) return;
+    _didPrepareTutorial = true;
+
+    final userProvider = Provider.of<UserProvider>(context, listen: false);
+    final tutorialProvider =
+        Provider.of<TutorialProvider>(context, listen: false);
+    await tutorialProvider.showAutoIntroIfNeeded(
+      userInfo: userProvider.userInfoModel,
+      isFirstLogin: userProvider.isFirstLogin,
+    );
+    userProvider.changeIsFirstLogin();
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) async {
     if (state == AppLifecycleState.resumed) {
@@ -239,14 +258,53 @@ class _MyHomePageState extends State<MyHomePage> with WidgetsBindingObserver {
   @override
   Widget build(BuildContext context) {
     final screenIndexProvider = Provider.of<ScreenIndexProvider>(context);
+    final tutorialProvider = Provider.of<TutorialProvider>(context);
+    _syncTutorialTab(tutorialProvider, screenIndexProvider);
 
-    return Scaffold(
-      body: IndexedStack(
-        index: screenIndexProvider.screenIndex,
-        children: _widgetOptions,
-      ),
-      bottomNavigationBar: _buildBottomNavigationBar(context),
+    final widgetOptions = <Widget>[
+      DirectoryScreen(tutorialTargets: _tutorialTargets),
+      PracticeThumbnailScreen(tutorialTargets: _tutorialTargets),
+      SettingScreen(tutorialTargets: _tutorialTargets),
+    ];
+
+    return Stack(
+      children: [
+        Scaffold(
+          body: IndexedStack(
+            index: screenIndexProvider.screenIndex,
+            children: widgetOptions,
+          ),
+          bottomNavigationBar: _buildBottomNavigationBar(context),
+        ),
+        TutorialOverlay(targets: _tutorialTargets),
+      ],
     );
+  }
+
+  void _syncTutorialTab(
+    TutorialProvider tutorialProvider,
+    ScreenIndexProvider screenIndexProvider,
+  ) {
+    if (!tutorialProvider.isRunning) {
+      _lastSyncedTutorialStepIndex = null;
+      return;
+    }
+
+    final stepIndex = tutorialProvider.currentStepIndex;
+    final targetTabIndex = tutorialProvider.currentStep.tabIndex;
+    if (_lastSyncedTutorialStepIndex == stepIndex &&
+        screenIndexProvider.screenIndex == targetTabIndex) {
+      return;
+    }
+
+    _lastSyncedTutorialStepIndex = stepIndex;
+    if (screenIndexProvider.screenIndex == targetTabIndex) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      Provider.of<ScreenIndexProvider>(context, listen: false)
+          .setSelectedIndex(targetTabIndex);
+    });
   }
 
   BottomNavigationBar _buildBottomNavigationBar(BuildContext context) {


### PR DESCRIPTION
## ✔️ 연관 이슈

- close #156 

## 📝 작업 내용

> 신규 사용자가 앱의 핵심 기능(공책 · 오답노트 · 복습 세트 · 리포트)을 처음 접할 때 자연스럽게 이해할 수 있도록 온보딩 튜토리얼을 도입했습니다.  
> 최초 로그인 시 자동으로 노출되며, 마이페이지 설정에서 언제든 다시 볼 수 있습니다.

### 주요 구현 내용

#### 1. 튜토리얼 상태 머신 (`TutorialProvider`)

- `TutorialStatus` enum: `idle → intro → running → outro → idle` 4단계 흐름
- **자동 노출 조건**: 최초 로그인 + 계정 생성 30분 이내 + 완료 이력 없음
- **완료 이력 저장**: `SharedPreferences` 기반, `userId × 버전` 단위로 키 관리 (`TutorialStorage`)
- **다시 보기**: `showReplayIntro(userId)` 호출 시 상태 초기화 후 인트로 재시작
- **Firebase Analytics** 이벤트: 각 상태 전환(intro_show, start, next, previous, skip, outro_show, complete) 로깅

#### 2. 튜토리얼 오버레이 UI (`TutorialOverlay`)

| 화면 | 설명 |
|------|------|
| **인트로 카드** | 개구리 말풍선 + 시작하기 / 건너뛰기 버튼 |
| **스텝 카드 (6단계)** | 대상 위젯 하이라이트 + 말풍선 카드 (이전 / 다음 / 건너뛰기) |
| **아웃트로 카드** | 완료 격려 메시지 + 이전 / 완료 버튼 |

- **개구리 말풍선** (`_buildFrogSpeech`): 캐릭터 이미지 + 말꼬리 커스텀 페인터(`_SpeechTailPainter`) + 테마 색상 연동 버블
- **하이라이트**: `AnimatedPositioned`로 대상 위젯에 테마 색상 테두리 및 글로우 효과 적용
- **스텝 전환**: `AnimatedSwitcher` fade + slide 애니메이션 (180 ms)
- **자동 탭 전환**: 스텝별 `tabIndex`에 따라 하단 탭 자동 전환 (`_syncTutorialTab`)
- **스크롤 대응**: `Scrollable.ensureVisible`로 대상 위젯이 뷰포트 내에 오도록 보정 (최대 4회 재시도)
- **태블릿 반응형**: `shortestSide >= 600` 기준으로 카드 너비 · 폰트 · 아이콘 크기 분기

#### 3. 튜토리얼 6단계 정의 (`TutorialStep`)

| 순서 | ID | 탭 | 대상 | 제목 |
|------|----|----|------|------|
| 1 | `folder_unit` | 홈 | 폴더 목록 | 공책과 오답노트 |
| 2 | `create_problem_note` | 홈 | 추가 FAB | 오답노트 작성 시작 |
| 3 | `practice_set` | 복습 | 복습 FAB | 복습 세트 |
| 4 | `level` | 마이 | 레벨 카드 | 레벨과 성장 |
| 5 | `calendar` | 마이 | 달력 카드 | 학습 달력 |
| 6 | `report` | 마이 | 리포트 카드 | 복습 리포트 |

#### 4. 마이페이지 다시 보기

- `SettingMenuButtons`에서 튜토리얼 항목을 분리하여 `_buildTutorialReplaySection` 독립 위젯으로 구성
- 탭을 홈(0)으로 이동 후 인트로 카드 재표시

### 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `lib/Provider/TutorialProvider.dart` | 튜토리얼 상태 머신, outro 상태 추가 |
| `lib/Screen/Tutorial/TutorialOverlay.dart` | 전체 오버레이 UI (인트로 · 스텝 · 아웃트로 · 말풍선) |
| `lib/Screen/Tutorial/TutorialStep.dart` | 6단계 스텝 정의, outro 상태 enum 추가, 설명 줄바꿈 적용 |
| `lib/Screen/Tutorial/TutorialStorage.dart` | SharedPreferences 완료 이력 저장 |
| `lib/Screen/Tutorial/TutorialTargets.dart` | 화면별 GlobalKey 보유 객체 |
| `lib/Screen/User/MyPageScreen.dart` | 튜토리얼 다시 보기 섹션 추가 |
| `lib/Screen/User/Widget/SettingMenuButtons.dart` | `onTutorialReplayTap` 파라미터 제거 |
| `lib/main.dart` | `TutorialOverlay` 마운트, 자동 노출 초기화, 탭 동기화 |

### 스크린샷 (선택)

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/561a8f21-b630-480c-ac03-da897d51d804" />
