### PR TITLE
[Feat] 인증 실패 시 로그인 화면 자동 전환

### DIFF
--- a/lib/Provider/TokenProvider.dart
+++ b/lib/Provider/TokenProvider.dart
@@ -22,6 +22,10 @@ class TokenProvider {
     await _onAuthFailure!();
   }
 
+  Future<void> notifyAuthFailure() async {
+    await _notifyAuthFailure();
+  }
+
   Future<void> setAccessToken(String accessToken) async {
     await storage.write(key: 'accessToken', value: accessToken);
   }

--- a/lib/Provider/UserProvider.dart
+++ b/lib/Provider/UserProvider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:core';
 import 'dart:developer';
 
@@ -14,10 +15,12 @@ import 'package:ono/Service/Api/Problem/ProblemService.dart';
 import 'package:ono/Service/Api/User/UserService.dart';
 import 'package:ono/Service/SocialLogin/KakaoAuthService.dart';
 import 'package:ono/Util/AppErrorReporter.dart';
+import 'package:ono/Util/AppNavigator.dart';
 import 'package:ono/Util/NotificationService.dart';
 
 import '../Exception/ApiException.dart';
 import '../Module/Text/StandardText.dart';
+import '../Screen/User/LoginScreen.dart';
 import '../Service/Api/HttpService.dart';
 import '../Service/SocialLogin/AppleAuthService.dart';
 import '../Service/SocialLogin/GoogleAuthService.dart';
@@ -45,6 +48,7 @@ class UserProvider with ChangeNotifier {
 
   LoginStatus _loginStatus = LoginStatus.waiting;
   bool _isFirstLogin = true;
+  bool _handlingAuthFailure = false;
   LoginStatus get isLoggedIn => _loginStatus;
   LoginStatus? get loginStatus => _loginStatus;
   bool get isFirstLogin => _isFirstLogin;
@@ -445,6 +449,46 @@ class UserProvider with ChangeNotifier {
 
   Future<void> _handleAuthFailure() async {
     if (_loginStatus == LoginStatus.logout) return;
-    await resetUserInfo();
+    if (_handlingAuthFailure) return;
+
+    _handlingAuthFailure = true;
+    final shouldNavigateToLogin = _loginStatus == LoginStatus.login;
+    try {
+      await resetUserInfo();
+    } finally {
+      _handlingAuthFailure = false;
+    }
+
+    if (!shouldNavigateToLogin) return;
+    _navigateToLoginAfterAuthFailure();
+  }
+
+  void _navigateToLoginAfterAuthFailure({int retryCount = 0}) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final navigator = AppNavigator.navigatorKey.currentState;
+      if (navigator == null) {
+        if (retryCount < 2) {
+          Future<void>.delayed(const Duration(milliseconds: 100), () {
+            _navigateToLoginAfterAuthFailure(retryCount: retryCount + 1);
+          });
+          return;
+        }
+
+        unawaited(
+          AppErrorReporter.report(
+            StateError('Navigator is not ready for auth failure redirect.'),
+            StackTrace.current,
+            source: 'auth_failure_navigation',
+            severity: AppErrorSeverity.warning,
+          ),
+        );
+        return;
+      }
+
+      navigator.pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const LoginScreen()),
+        (route) => false,
+      );
+    });
   }
 }

--- a/lib/Screen/User/SplashScreen.dart
+++ b/lib/Screen/User/SplashScreen.dart
@@ -22,17 +22,21 @@ class _SplashScreenState extends State<SplashScreen> {
   }
 
   // 유저의 로그인 상태를 확인하는 함수
-  _checkLoginStatus() async {
+  Future<void> _checkLoginStatus() async {
     // UserProvider에서 로그인 상태를 가져옴
     final userProvider = Provider.of<UserProvider>(context, listen: false);
     await userProvider.autoLogin();
+    if (!mounted) return;
 
     print('login status: ${userProvider.loginStatus}');
     // 2초간 대기 후 상태 체크
 
     await Future.delayed(const Duration(milliseconds: 1500), () {});
+    if (!mounted) return;
+
     while (userProvider.loginStatus == LoginStatus.waiting) {
       await Future.delayed(const Duration(milliseconds: 500));
+      if (!mounted) return;
     }
 
     // 로그인 상태에 따른 화면 이동

--- a/lib/Service/Api/HttpService.dart
+++ b/lib/Service/Api/HttpService.dart
@@ -297,12 +297,15 @@ class HttpService {
       if (errorCode != null) {
         // 인증 관련 에러 코드
         if (errorCode >= 1000 && errorCode < 2000) {
+          if (requiredToken) {
+            await tokenProvider.notifyAuthFailure();
+          }
           _throwWithSnackBar(
             UnauthorizedException(
               errorCode: errorCode,
               message: message,
             ),
-            showErrorSnackBar: showErrorSnackBar,
+            showErrorSnackBar: requiredToken ? false : showErrorSnackBar,
           );
         }
         // 기타 비즈니스 로직 에러는 BadRequestException으로 처리
@@ -318,12 +321,15 @@ class HttpService {
 
       // errorCode가 없을 경우 상태 코드로 판단
       if (status == 401) {
+        if (requiredToken) {
+          await tokenProvider.notifyAuthFailure();
+        }
         _throwWithSnackBar(
           UnauthorizedException(
             errorCode: errorCode,
             message: message,
           ),
-          showErrorSnackBar: showErrorSnackBar,
+          showErrorSnackBar: requiredToken ? false : showErrorSnackBar,
         );
       } else if (status >= 400 && status < 500) {
         _throwWithSnackBar(


### PR DESCRIPTION
## ✔️ 연관 이슈

- 없음

## 📝 작업 내용

인증이 필요한 API 요청에서 401 또는 인증 계열 에러가 발생하면 사용자 정보를 초기화하고 로그인 화면으로 자동 전환하도록 처리했습니다.

- `HttpService`에서 토큰이 필요한 요청의 인증 실패를 감지해 `TokenProvider.notifyAuthFailure()`를 호출합니다.
- `UserProvider`에서 인증 실패 중복 처리를 막고, 로그인 상태였던 사용자만 로그인 화면으로 이동시킵니다.
- Navigator 준비가 늦는 경우 짧게 재시도하고, 실패 시 경고 수준으로 리포팅합니다.
- `SplashScreen`의 비동기 로그인 상태 확인 중 `mounted` 체크를 추가해 화면 종료 후 이동 로직이 실행되지 않도록 방어했습니다.

### 사용자 영향

- 세션 만료 또는 잘못된 토큰 상태에서 앱이 어중간한 화면에 남지 않고 로그인 화면으로 돌아갑니다.
- 인증 실패 시 중복 스낵바 노출을 줄이고, 재로그인 흐름을 더 명확하게 만듭니다.

### 반응형 대응

- 별도 UI 레이아웃 변경은 없습니다.
- 로그인 화면 전환 흐름만 변경되므로 폰/태블릿 레이아웃 영향은 제한적입니다.

### 검증

- `git fetch origin develop`: 성공
- `flutter analyze`: 실행했으나 기존 lint/info/warning 477개로 종료 코드 1 반환
  - 이번 변경 범위에서 새 컴파일 오류는 출력상 확인되지 않았습니다.
  - 기존 파일명 규칙, deprecated API, unused element, async context 관련 경고가 다수 남아 있습니다.

### 배포 리스크 / 확인 필요 사항

- 인증 실패 시 즉시 로그인 화면으로 이동하므로, 저장 중이던 화면 상태는 사라질 수 있습니다.
- 실제 401 응답 시나리오에서 중복 네비게이션이 발생하지 않는지 QA 확인이 필요합니다.
- 백엔드의 인증 에러 코드 범위가 현재처럼 `1000 <= errorCode < 2000`이라는 전제에 의존합니다.

### 스크린샷 (선택)

- UI 레이아웃 변경이 없어 별도 스크린샷은 생략 가능합니다.