### PR TITLE
[Chore] 작업 모드 PR/이슈 자동화 개선

### DIFF
--- a/.agents/skills/ono-issue/SKILL.md
+++ b/.agents/skills/ono-issue/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ono-issue
+description: OnO Flutter 레포에서 사용자가 "/issue <내용>" 또는 "issue <내용>"을 입력하면 GitHub 이슈 템플릿에 맞춰 AI-SIP/OnO_FRONT 이슈를 생성한다. 파일 경로가 주어지면 파일 내용을 읽어 이슈 내용을 구성한다.
+---
+
+# OnO Issue Skill
+
+사용자가 `/issue <내용>` 또는 `issue <내용>` 형태로 요청하면 이 Skill을 따른다.
+
+## 목표
+
+사용자가 자유롭게 적은 설명이나 전달한 파일 내용을 바탕으로 `AI-SIP/OnO_FRONT` GitHub Repository에 실제 이슈를 생성한다. 이슈는 `.github/ISSUE_TEMPLATE` 아래 템플릿 형식에 맞춰 작성한다.
+
+## 고정값
+
+- Repository: `AI-SIP/OnO_FRONT`
+- Assignee: `KiSeungMin`
+- 생성 도구: 가능한 경우 GitHub MCP의 `issue_write` create 작업을 사용한다.
+
+## 절차
+
+1. 사용자 입력에서 이슈 원문과 파일 경로를 구분한다.
+2. 파일 경로가 있으면 해당 파일을 읽고, 여러 파일이면 이슈 작성에 필요한 핵심 내용만 요약한다.
+3. `.github/ISSUE_TEMPLATE/bug-report-template.md`와 `.github/ISSUE_TEMPLATE/common-issue-template.md`를 읽는다.
+4. 내용이 실제 버그, 오류, 크래시, 화면 깨짐, 재현 조건, 예상/실제 결과를 포함하면 bug 템플릿을 선택한다.
+5. 기능 추가, 개선, 리팩터링, 문서화, 작업 TODO 성격이면 common 템플릿을 선택한다.
+6. 사용자가 타입을 명시하지 않았으면 아래 기준으로 제목 prefix, label, type을 추론한다.
+7. 추론이 어려워도 이슈 생성이 가능하면 가장 보수적인 common 이슈로 생성하고, 본문 `ETC`에 확인 필요 사항을 남긴다.
+8. GitHub 이슈를 생성한 뒤 이슈 번호, URL, 적용한 template/type/label/assignee를 보고한다.
+
+## 타입과 라벨 추론
+
+- 버그, 오류, 크래시, 예외, 화면 깨짐, 동작 불일치: 제목 prefix `[bug]`, label `bug`, type은 저장소가 지원하면 `Bug`
+- 새 기능, 사용자 기능 추가, 화면 추가: 제목 prefix `[feat]`, label은 저장소에 `feature` 또는 `enhancement`가 있으면 적용, type은 저장소가 지원하면 `Feature`
+- UI/UX 개선, 문구 개선, 사용성 개선: 제목 prefix `[improve]`, label은 저장소에 `enhancement`가 있으면 적용
+- 리팩터링, 구조 정리: 제목 prefix `[refactor]`, label은 저장소에 `refactor`가 있으면 적용
+- 문서, README, 명세: 제목 prefix `[docs]`, label은 저장소에 `documentation` 또는 `docs`가 있으면 적용
+- 설정, 빌드, 의존성, 기타 작업: 제목 prefix `[chore]`, label은 저장소에 `chore`가 있으면 적용
+
+저장소에 어떤 label/type이 존재하는지 확인할 수 있는 도구가 있으면 먼저 조회한다. 확인할 수 없거나 유효성 오류가 우려되면 label/type은 생략하고 제목 prefix와 본문으로 의도를 명확히 한다.
+
+## 본문 작성 규칙
+
+### Bug Report Template
+
+아래 항목을 채운다.
+
+- `## ⚙️ 어떤 버그인가요?`: 한두 문장으로 버그 요약
+- `### 스크린샷(선택)`: 사용자가 스크린샷이나 이미지 경로를 제공한 경우만 언급
+- `## 🔎 어떤 상황에서 발생한 버그인가요?`: 재현 조건을 Given-When-Then 또는 번호 목록으로 정리
+- `## ✅ 예상 결과`: 기대 동작을 사용자 관점으로 작성
+
+알 수 없는 항목은 지어내지 않고 `확인 필요`로 표시한다.
+
+### Common Issue Template
+
+아래 항목을 채운다.
+
+- `## 📝 Description`: 작업 목표와 배경을 짧게 정리
+- `## ✅ TODO`: 실행 가능한 작업 항목을 체크박스로 작성
+- `## 💡 ETC (선택)`: 참고 파일, 확인 필요 사항, API/디자인/반응형 주의점이 있을 때만 작성
+
+TODO는 과하게 쪼개지 말고 실제 구현자가 바로 이해할 수 있는 단위로 작성한다.
+
+## 주의
+
+- 실제 운영 중인 앱 기준으로 사용자 영향, 반응형, API 계약, null/빈 상태/에러 상태 위험을 본문에 필요한 만큼 포함한다.
+- 사용자가 준 내용을 과장하거나 임의 요구사항을 추가하지 않는다.
+- 제목은 짧고 구체적으로 작성한다.
+- 한국어 문구는 자연스럽고 간결하게 작성한다.
+- GitHub 생성에 실패하면 오류 원인과 필요한 권한을 짧게 보고한다.

--- a/.agents/skills/ono-pr/SKILL.md
+++ b/.agents/skills/ono-pr/SKILL.md
@@ -1,38 +1,71 @@
 ---
 name: ono-pr
-description: OnO Flutter 레포에서 사용자가 "pr <커밋 해쉬>"를 입력하거나 PR 제목/본문 초안 작성을 요청할 때 사용한다. 지정 커밋부터 현재까지 diff를 분석해 PR 문서를 작성한다.
+description: OnO Flutter 레포에서 사용자가 "pr" 또는 "pr <기준 커밋>"을 입력하면 현재 브랜치의 개발 내역을 바탕으로 develop 브랜치 대상 GitHub PR을 생성한다.
 ---
 
 # OnO PR Skill
 
-사용자가 `pr <커밋 해쉬>` 형태로 요청하면 이 Skill을 따른다. 인자가 없으면 현재 작업 중인 변경사항(`git status`, staged/unstaged diff, untracked 파일)을 기준으로 PR 초안을 작성한다.
+사용자가 `pr` 또는 `pr <기준 커밋>` 형태로 요청하면 이 Skill을 따른다.
 
 ## 목표
 
-입력한 커밋부터 현재 작업 상태까지의 변경사항을 분석해 `.github/PULL_REQUEST_TEMPLATE.md` 형식에 맞는 PR 제목과 본문 초안을 작성한다. 커밋 해시가 없으면 현재 변경사항만 기준으로 작성한다.
+현재 브랜치의 개발 내역을 분석해 `AI-SIP/OnO_FRONT` GitHub Repository에서 현재 브랜치를 `develop` 브랜치에 merge 요청하는 PR을 실제로 생성한다.
+
+## 고정값
+
+- Repository: `AI-SIP/OnO_FRONT`
+- Base branch: `develop`
+- Head branch: 현재 로컬 브랜치
+- Assignee: `KiSeungMin`
+- Reviewers: 지정하지 않음
+- Milestone, project, linked development: 지정하지 않음
+- `main` 대상 PR은 생성하지 않음
 
 ## 절차
 
-1. 기준 커밋 해시가 있으면 `git log`, `git diff <커밋>..HEAD`, 현재 uncommitted diff를 확인한다.
-2. 기준 커밋 해시가 없으면 `git status`, staged/unstaged diff, untracked 파일을 확인해 현재 변경사항 기준으로 작성한다.
-3. `.github/PULL_REQUEST_TEMPLATE.md`를 반드시 읽는다.
-4. 관련 `docs` 기능 문서 폴더를 찾는다.
-5. 저장할 기능 문서 폴더가 명확하지 않으면 사용자에게 확인한다.
-6. PR 문서를 해당 기능 문서 폴더 아래 markdown 파일로 저장한다.
+1. `git branch --show-current`로 현재 브랜치를 확인한다.
+2. 현재 브랜치가 `main`, `master`, `develop`이면 PR을 만들지 말고 사용자에게 중단 사유를 보고한다.
+3. `git status --short`로 uncommitted 변경사항을 확인한다. 커밋되지 않은 변경이 있으면 PR에 포함되지 않는다는 점을 알리고, 사용자가 명시적으로 계속 요청하지 않는 한 PR 생성을 중단한다.
+4. `git fetch origin develop`이 가능하면 실행해 비교 기준을 최신화한다. 실행하지 못하면 로컬 `develop` 또는 `origin/develop` 기준으로 분석하고 남은 리스크를 보고한다.
+5. 기준 커밋이 있으면 `git log <기준 커밋>..HEAD --oneline`과 `git diff <기준 커밋>..HEAD`를 확인한다.
+6. 기준 커밋이 없으면 `git log origin/develop..HEAD --oneline`과 `git diff origin/develop..HEAD`를 확인한다. `origin/develop`이 없으면 `develop..HEAD`를 사용한다.
+7. GitHub에서 현재 브랜치명, 커밋 메시지, 변경사항 키워드와 관련된 open issue를 먼저 검색한다.
+8. 관련 이슈가 명확하면 PR body의 연관 이슈 항목에 `close #번호`를 포함한다. 여러 개면 모두 포함한다.
+9. 관련 이슈가 불명확하면 임의로 연결하지 않고 `없음` 또는 `확인 필요`로 작성한다.
+10. `.github/PULL_REQUEST_TEMPLATE.md`를 반드시 읽고 그 형식에 맞춰 PR body를 작성한다.
+11. 변경사항 성격에 맞춰 PR title과 label 후보를 정한다.
+12. GitHub MCP 또는 GitHub CLI로 PR을 생성한다.
+13. PR 생성 후 PR 번호를 대상으로 assignee `KiSeungMin`을 추가하고, 유효한 label만 추가한다. PR은 GitHub issue와 번호를 공유하므로 issue/label/assignee 도구를 사용할 수 있다.
+14. 생성된 PR 번호, URL, base/head, assignee, label, 연결한 이슈, 검증 여부를 보고한다.
 
-## PR 문서 포함 항목
+## 제목과 라벨 기준
 
-- PR 제목
-- 연관 이슈
-- 작업 내용
-- 사용자 영향
-- 반응형 대응
-- 검증 결과
-- 배포 리스크
-- 스크린샷 필요 여부
+- 기능 추가, 사용자 기능 변경: 제목 prefix `[Feat]`, label 후보 `feature`, `enhancement`
+- 버그 수정, 크래시/오류 수정: 제목 prefix `[Fix]`, label 후보 `bug`
+- 리팩터링, 구조 정리: 제목 prefix `[Refactor]`, label 후보 `refactor`
+- 문서 변경: 제목 prefix `[Docs]`, label 후보 `documentation`, `docs`
+- 테스트 변경: 제목 prefix `[Test]`, label 후보 `test`
+- 빌드, 설정, 의존성, 기타 작업: 제목 prefix `[Chore]`, label 후보 `chore`
+
+저장소에 어떤 label이 존재하는지 확인할 수 있으면 먼저 조회한다. 확인할 수 없거나 유효성 오류가 우려되면 label은 생략하고 PR 제목과 본문으로 변경 성격을 명확히 한다.
+
+## PR 본문 포함 항목
+
+- GitHub에서 검색한 연관 이슈가 명확하면 `close #번호`, 없으면 `없음` 또는 `확인 필요`
+- 사용자 관점의 작업 내용
+- 주요 변경사항
+- UI 변경이 있으면 반응형 대응 여부
+- 실행한 검증 결과
+- 배포 리스크 또는 확인 필요 사항
+- 스크린샷이 필요한 UI 변경이면 스크린샷 필요 여부
 
 ## 주의
 
-- 실제 PR 생성, push, branch 변경은 사용자 요청 없이는 하지 않는다.
+- 이 명령은 실제 PR을 생성한다.
+- base branch는 항상 `develop`이다.
+- `main` 대상 PR은 생성하지 않는다.
+- 현재 브랜치를 push해야 PR 생성이 가능하지만 원격 브랜치가 없으면 사용자에게 push 필요 여부를 확인한다. 사용자가 명시적으로 허용하기 전에는 push하지 않는다.
+- Reviewers는 지정하지 않는다.
+- Assignee는 항상 `KiSeungMin`으로 지정한다.
 - 변경사항을 과장하지 않는다.
 - 검증하지 않은 항목은 검증했다고 쓰지 않는다.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,102 @@
+---
+description: AI-SIP/OnO_FRONT 리포지토리에 GitHub 이슈 생성
+argument-hint: "<이슈 설명 또는 파일 경로>"
+---
+
+$ARGUMENTS 내용을 바탕으로 AI-SIP/OnO_FRONT 리포지토리에 GitHub 이슈를 생성한다.
+
+**코드를 수정하지 않는다.**
+**Assignee는 항상 `KiSeungMin`으로 지정한다.**
+**이슈 본문은 `.github/ISSUE_TEMPLATE` 아래 템플릿 형식에 맞춘다.**
+
+---
+
+## 1단계 – 입력 파악
+
+`$ARGUMENTS`가 파일 경로처럼 보이면 해당 파일을 읽어 내용을 파악한다.  
+아니면 텍스트 그대로를 이슈 내용으로 사용한다.
+
+입력 파일이 여러 개면 모든 내용을 그대로 붙이지 말고 이슈 생성에 필요한 핵심만 요약한다.
+
+---
+
+## 2단계 – 이슈 분류
+
+먼저 아래 템플릿을 읽고, 입력 내용을 보고 **템플릿**, **label**, **type**을 결정한다.
+
+- `.github/ISSUE_TEMPLATE/bug-report-template.md`
+- `.github/ISSUE_TEMPLATE/common-issue-template.md`
+
+| 내용 성격 | 템플릿 | label 후보 | type 후보 | title 접두사 |
+|---|---|---|---|---|
+| 비정상 동작, 크래시, 오류, 화면 깨짐 | Bug Report | `bug` | `Bug` | `[bug]` |
+| 새 기능, 화면, API 연동 | Common Issue | `feature`, `enhancement` | `Feature` | `[feat]` |
+| 사용성, UI/UX, 문구 개선 | Common Issue | `enhancement` | `Feature` | `[improve]` |
+| 성능 개선, 코드 정리 | Common Issue | `refactor` | 없음 | `[refactor]` |
+| 배포, 설정, 문서, 의존성 | Common Issue | `chore`, `documentation`, `docs` | 없음 | `[chore]` |
+| 테스트 추가/수정 | Common Issue | `test` | 없음 | `[test]` |
+
+가능하면 저장소에 존재하는 label/type을 먼저 확인한다. 존재 여부를 확인할 수 없거나 유효성 오류가 우려되면 label/type은 생략하고 제목 접두사와 본문으로 의도를 명확히 한다. 모호하면 가장 가까운 common 이슈로 판단하고 `ETC`에 확인 필요 사항을 남긴다.
+
+---
+
+## 3단계 – 이슈 본문 작성
+
+### Bug Report 템플릿 (`label: bug`)
+
+```
+## ⚙️ 어떤 버그인가요?
+
+<입력 내용을 바탕으로 간결하게 설명>
+
+### 스크린샷(선택)
+
+## 🔎 어떤 상황에서 발생한 버그인가요?
+
+> Given: <전제 상황>
+> When: <어떤 행동을 했을 때>
+> Then: <어떤 문제가 발생했는지>
+
+## ✅ 예상 결과
+
+<정상적으로 동작했어야 하는 결과>
+```
+
+### Common Issue 템플릿 (`label: feature / refactor / chore / test`)
+
+```
+## 📝 Description
+
+<입력 내용을 바탕으로 작업 설명>
+
+## ✅ TODO
+
+- [ ] <핵심 작업 1>
+- [ ] <핵심 작업 2>
+(입력 내용에서 파악 가능한 TODO를 최대한 구체적으로 작성)
+
+## 💡 ETC (선택)
+
+<입력 내용에서 기타 고려사항이 있으면 작성, 없으면 생략>
+```
+
+---
+
+## 4단계 – GitHub 이슈 생성
+
+`mcp__github__issue_write` 툴로 이슈를 생성한다.
+
+- **owner**: `AI-SIP`
+- **repo**: `OnO_FRONT`
+- **method**: `create`
+- **assignees**: `["KiSeungMin"]` (항상 고정)
+- **title**: `[접두사] <한 줄 요약>` 형식
+- **labels**: 위 분류 기준에 따라 설정하되, 저장소에 존재하는 label만 사용
+- **type**: 저장소가 지원하고 유효한 type일 때만 설정
+- **body**: 3단계에서 작성한 본문
+
+---
+
+## 5단계 – 결과 보고
+
+생성된 이슈 번호와 URL, 적용한 템플릿/type/label/assignee를 사용자에게 알린다.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,29 +1,107 @@
 ---
-description: 커밋부터 현재까지 변경사항 기반 PR 초안 작성
-argument-hint: "<기준 커밋 해시>"
+description: 현재 브랜치 개발 내역을 develop 브랜치로 merge 요청하는 GitHub PR 생성
+argument-hint: "[기준 커밋 해시]"
 ---
 
-$ARGUMENTS 커밋부터 현재까지의 변경사항을 분석해 PR 초안을 작성한다.
+현재 브랜치의 개발 내역을 분석해 `AI-SIP/OnO_FRONT` 리포지토리에서 현재 브랜치를 `develop` 브랜치에 merge 요청하는 GitHub PR을 생성한다.
 
-**1단계 – 변경사항 파악**
+**고정 규칙**
+
+- base branch는 항상 `develop`
+- head branch는 현재 브랜치
+- assignee는 항상 `KiSeungMin`
+- reviewers는 지정하지 않음
+- milestone, project 등 나머지 항목은 지정하지 않음
+- `main` 대상 PR은 절대 생성하지 않음
+
+**1단계 - 브랜치와 작업 상태 확인**
+
+```
+git branch --show-current
+git status --short
+```
+
+현재 브랜치가 `main`, `master`, `develop`이면 PR을 생성하지 않는다. 커밋되지 않은 변경사항이 있으면 PR에 포함되지 않는다고 보고하고, 사용자가 명시적으로 계속 요청하지 않는 한 PR 생성을 중단한다.
+
+**2단계 - 변경사항 파악**
+
+가능하면 `git fetch origin develop`으로 비교 기준을 최신화한다.
+
+`$ARGUMENTS` 기준 커밋이 있으면:
+
 ```
 git log <커밋해시>..HEAD --oneline
 git diff <커밋해시>..HEAD
 ```
 
-**2단계 – PR 템플릿 확인**
+기준 커밋이 없으면:
+
+```
+git log origin/develop..HEAD --oneline
+git diff origin/develop..HEAD
+```
+
+`origin/develop`이 없으면 `develop..HEAD`를 사용한다.
+
+**3단계 - 연관 이슈 검색**
+
+`mcp__github__search_issues` 또는 `mcp__github__list_issues` 툴로 `AI-SIP/OnO_FRONT` 저장소의 open 이슈 중 연관된 것을 찾는다.
+
+검색 키워드 순서:
+1. 브랜치명에서 타입 접두사(`feat/`, `fix/` 등)를 제거한 핵심 단어
+2. 커밋 메시지에서 반복되는 명사·동사 조합
+3. 위 두 가지로 찾지 못하면 추가 검색 없이 없음으로 처리
+
+연관 이슈가 명확하면 PR body의 연관 이슈 항목에 `close #번호`를 포함한다. 여러 개면 모두 포함한다. 관련 이슈가 불명확하면 임의로 연결하지 않고 `없음` 또는 `확인 필요`로 작성한다.
+
+**4단계 - PR 템플릿 확인**
+
 `.github/PULL_REQUEST_TEMPLATE.md` 양식을 반드시 확인하고 그 형식을 따른다.
 
-**3단계 – PR 초안 작성**
-PR 문서를 `/plan` 명세서와 같은 `docs/` 하위 폴더에 저장한다.
-어떤 폴더를 사용할지 명확하지 않으면 사용자에게 확인한다.
+**5단계 - PR 제목, 본문, label 결정**
 
 PR 내용에 포함할 항목:
-- 변경사항 요약 (사용자 관점)
-- 주요 구현 내용 (파일:라인 참조)
+
+- 3단계에서 연관 이슈를 찾았으면 `close #이슈번호`, 없으면 `없음` 또는 `확인 필요`
+- 사용자 관점의 작업 내용
+- 주요 변경사항
 - 반응형 대응 여부 (UI 변경이 있는 경우)
 - 실행한 검증 결과 (`flutter analyze`, 테스트)
 - 배포 리스크 및 확인이 필요한 부분
 - 스크린샷 안내 (해당하는 경우)
 
-**규칙**: 이 명령은 읽기 전용이다. 코드를 수정하거나 실제로 PR을 올리지 않는다.
+label 후보:
+
+| 변경 성격 | title 접두사 | label 후보 |
+|---|---|---|
+| 기능 추가, 사용자 기능 변경 | `[Feat]` | `feature`, `enhancement` |
+| 버그 수정, 오류 수정 | `[Fix]` | `bug` |
+| 리팩터링, 구조 정리 | `[Refactor]` | `refactor` |
+| 문서 변경 | `[Docs]` | `documentation`, `docs` |
+| 테스트 변경 | `[Test]` | `test` |
+| 빌드, 설정, 의존성, 기타 작업 | `[Chore]` | `chore` |
+
+가능하면 저장소에 존재하는 label을 먼저 확인한다. 존재 여부를 확인할 수 없거나 유효성 오류가 우려되면 label은 생략한다.
+
+**6단계 - GitHub PR 생성**
+
+가능한 도구를 사용해 PR을 생성한다.
+
+- repository: `AI-SIP/OnO_FRONT`
+- base: `develop`
+- head: 현재 브랜치
+- title: `[접두사] <한 줄 요약>`
+- body: `.github/PULL_REQUEST_TEMPLATE.md` 형식
+- draft: false
+
+PR 생성 후 PR 번호를 대상으로 assignee와 label을 설정한다. GitHub PR은 issue 번호를 공유하므로 issue assignee/label 도구를 사용할 수 있다.
+
+- assignees: `["KiSeungMin"]`
+- labels: 존재하는 label만 추가
+- reviewers: 생략
+
+원격에 현재 브랜치가 없어 PR 생성이 실패하면, push가 필요하다고 보고하고 사용자의 명시적 허용 없이는 push하지 않는다.
+
+**7단계 - 결과 보고**
+
+생성된 PR 번호와 URL, base/head, assignee, label, 연결한 이슈, 실행한 검증과 남은 리스크를 보고한다.

--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -1,0 +1,44 @@
+name: Close linked issues on develop merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Parse and close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+
+            // close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issueNumbers = [...body.matchAll(pattern)].map(m => parseInt(m[1]));
+
+            if (issueNumbers.length === 0) {
+              console.log('연결된 이슈 없음');
+              return;
+            }
+
+            const unique = [...new Set(issueNumbers)];
+            console.log(`닫을 이슈: ${unique.join(', ')}`);
+
+            for (const issue_number of unique) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              console.log(`#${issue_number} 닫음`);
+            }


### PR DESCRIPTION
## ✔️ 연관 이슈

- 없음

## 📝 작업 내용

OnO 프론트엔드 작업 모드에서 PR과 이슈를 실제 GitHub 작업까지 이어서 처리할 수 있도록 에이전트 지침과 Claude 명령어를 정리했습니다. develop 브랜치로 PR이 merge될 때 PR 본문의 `close #번호`를 기준으로 연결 이슈를 닫는 GitHub Actions 워크플로우도 추가했습니다.

- `/pr` 명령을 PR 초안 작성에서 GitHub PR 실제 생성 절차로 개선했습니다.
- `/issue` 명령과 `ono-issue` Skill을 추가해 GitHub 이슈 템플릿 기반 생성 절차를 정의했습니다.
- PR 생성 시 `develop` base, 현재 브랜치 head, `KiSeungMin` assignee, 연관 이슈 검색/연결 규칙을 문서화했습니다.
- develop 대상 PR merge 이후 PR 본문의 `close`, `fix`, `resolve` 키워드를 파싱해 연결 이슈를 closed 처리하는 workflow를 추가했습니다.

### 사용자 영향

- 작업자가 `pr`, `/issue` 명령을 사용할 때 문서 초안에 그치지 않고 실제 GitHub PR/Issue 생성까지 일관된 규칙으로 진행할 수 있습니다.
- PR body에 연결 이슈를 명확히 적으면 develop merge 시 이슈 종료가 자동화됩니다.

### 반응형 대응

- Flutter 앱 UI 변경은 없습니다.
- 폰/태블릿 화면 레이아웃에는 영향이 없습니다.

### 검증

- `git fetch origin develop`: 성공
- GitHub open issue 검색: `agent`, `PR issue workflow` 키워드로 검색했으나 명확한 연관 이슈 없음
- `git diff --check 0a65031d^..HEAD`: trailing whitespace 1건으로 실패
  - `.claude/commands/issue.md:16`
- Flutter 앱 코드 변경이 없어 `flutter analyze`는 실행하지 않았습니다.

### 배포 리스크 / 확인 필요 사항

- `.github/workflows/close-issues-on-merge.yml`은 GitHub Actions 권한과 이벤트 조건에 의존하므로 실제 develop merge 후 1회 동작 확인이 필요합니다.
- PR 본문에 의도치 않은 `close #번호` 형태가 있으면 해당 이슈가 닫힐 수 있으므로 PR 작성 시 연결 이슈 항목을 정확히 관리해야 합니다.
- `.claude/commands/issue.md`에 trailing whitespace 1건이 남아 있습니다.

### 스크린샷 (선택)

- UI 변경이 없어 스크린샷은 생략 가능합니다.